### PR TITLE
test: fix Action Fusion renderer assertion in SoL-Pi checkouts

### DIFF
--- a/tests/action-fusion.test.ts
+++ b/tests/action-fusion.test.ts
@@ -118,26 +118,32 @@ describe("action fusion then_run", () => {
 		expect(edit.name).toBe("edit");
 	});
 
-	it("renders a fused mutation as an English lightning savings call", () => {
+	it.each([
+		{ label: "default checkout name", cwd: join(tmpdir(), "SoL-Pi"), path: "target.ts" },
+		{ label: "unrelated checkout name", cwd: join(tmpdir(), "plain-checkout"), path: "target.ts" },
+		{ label: "repository name in the target path", cwd: join(tmpdir(), "plain-checkout"), path: "SoL-Pi/target.ts" },
+	])("renders a fused mutation as an English lightning savings call ($label)", ({ cwd, path }) => {
 		const { write } = loadFusedTools();
 		const fusedArgs = {
-			path: "target.ts",
+			path,
 			content: "export {};\n",
 			then_run: { command: "npm test" },
 		};
 		const fused = write.renderCall!(fusedArgs, plainTheme, {
-			cwd: process.cwd(),
+			cwd,
 			args: fusedArgs,
 		} as never);
-		const plainArgs = { path: "target.ts", content: "export {};\n" };
+		const plainArgs = { path, content: "export {};\n" };
 		const plain = write.renderCall!(plainArgs, plainTheme, {
-			cwd: process.cwd(),
+			cwd,
 			args: plainArgs,
 		} as never);
 
 		expect(componentText(fused)).toContain("⚡ SoL-Pi · Action Fusion");
 		expect(componentText(fused)).toContain("Money saved · 1 model round-trip avoided");
-		expect(componentText(plain)).not.toContain("SoL-Pi");
+		// A normal path or its OSC 8 hyperlink may contain the repository name.
+		expect(componentText(plain)).not.toContain("⚡ SoL-Pi · Action Fusion");
+		expect(componentText(plain)).not.toContain("Money saved · 1 model round-trip avoided");
 	});
 
 	it("runs write then_run through bash after the written content is visible", async () => {


### PR DESCRIPTION
## Summary

Fixes #1.

Check the complete Action Fusion branding and savings text instead of rejecting every occurrence of `SoL-Pi`. A normal target path or an invisible OSC 8 hyperlink can legitimately contain the repository name.

The renderer test now covers the default checkout name, an unrelated checkout name, and a target path containing `SoL-Pi`. This is a test-only change; runtime behavior is unchanged.

## Validation

- Before the assertion fix, the default-checkout and target-path cases failed with hyperlinks enabled.
- `env -u TMUX TERM=xterm-256color TERM_PROGRAM=vscode npm run check`: passed, 124 tests across 16 files, plus typecheck and package dry run.
- `env -u TMUX TERM=screen TERM_PROGRAM= npm test -- --run tests/action-fusion.test.ts`: passed, 16 tests with hyperlinks disabled.
- `node scripts/check-pi-compat.mjs`: passed.
- `npx --no-install vitest run tests/all-mechanisms.test.ts`: passed, 4 tests.
- `npm audit --audit-level=high`: passed. The unchanged lockfile currently has two moderate Vitest-related advisories; no dependency changes are included.

Tested with Node 26.0.0 and Pi 0.84.2. Independent of the file-URL fix for #2.
