### PR TITLE
fix: price compaction from the actual removable prefix

### DIFF
--- a/src/sol-pi/extensions/online-context-compact/extension.ts
+++ b/src/sol-pi/extensions/online-context-compact/extension.ts
@@ -87,13 +87,15 @@ function progressSummary(input: PlanUpdateInput, completedStepId: string): Progr
 	};
 }
 
-function compactionMessageCount(entries: readonly SessionEntry[], startIndex: number, endIndex: number): number {
-	let count = 0;
+function compactionTokenEstimate(entries: readonly SessionEntry[], startIndex: number, endIndex: number): number {
+	let tokens = 0;
 	for (let index = startIndex; index < endIndex; index++) {
 		const entry = entries[index];
-		if (entry && entry.type !== "compaction" && sessionEntryToContextMessages(entry).length > 0) count++;
+		if (!entry || entry.type === "compaction") continue;
+		const message = sessionEntryToContextMessages(entry)[0];
+		if (message) tokens += estimateTokens(message);
 	}
-	return count;
+	return tokens;
 }
 
 function branchAfterAbort(entries: readonly SessionEntry[]): SessionEntry[] {
@@ -127,25 +129,33 @@ function branchAfterAbort(entries: readonly SessionEntry[]): SessionEntry[] {
 	];
 }
 
-function nativeCompactionFeasible(entries: readonly SessionEntry[], keepRecentTokens: number): boolean {
+export function estimateNativeCompactionTokens(
+	entries: readonly SessionEntry[],
+	keepRecentTokens: number,
+): number {
 	const path = branchAfterAbort(entries);
 	let startIndex = 0;
+	let previousSummaryTokens = 0;
 	for (let index = path.length - 1; index >= 0; index--) {
 		const entry = path[index];
 		if (entry?.type !== "compaction") continue;
 		const keptIndex = path.findIndex((item) => item.id === entry.firstKeptEntryId);
 		startIndex = keptIndex >= 0 ? keptIndex : index + 1;
+		const previousSummary = sessionEntryToContextMessages(entry)[0];
+		previousSummaryTokens = previousSummary ? estimateTokens(previousSummary) : 0;
 		break;
 	}
 
 	const cut = findCutPoint(path, startIndex, path.length, keepRecentTokens);
 	const historyEnd = cut.isSplitTurn ? cut.turnStartIndex : cut.firstKeptEntryIndex;
-	const historyMessages = historyEnd > startIndex ? compactionMessageCount(path, startIndex, historyEnd) : 0;
-	const prefixMessages =
+	const historyTokens =
+		historyEnd > startIndex ? compactionTokenEstimate(path, startIndex, historyEnd) : 0;
+	const prefixTokens =
 		cut.isSplitTurn && cut.turnStartIndex >= 0
-			? compactionMessageCount(path, cut.turnStartIndex, cut.firstKeptEntryIndex)
+			? compactionTokenEstimate(path, cut.turnStartIndex, cut.firstKeptEntryIndex)
 			: 0;
-	return historyMessages > 0 || prefixMessages > 0;
+	const newHistoryTokens = historyTokens + prefixTokens;
+	return newHistoryTokens > 0 ? previousSummaryTokens + newHistoryTokens : 0;
 }
 
 function validPositiveInteger(value: unknown): value is number {
@@ -275,8 +285,10 @@ export function createOnlineContextCompactExtension(options: OnlineContextCompac
 
 			const usage = context.getContextUsage();
 			const writeTokens = contextTokens(context);
-			const fixedTokens = tokenEstimate(context.getSystemPrompt());
-			const archiveTokens = Math.max(0, writeTokens - fixedTokens - keepRecentTokens);
+			const archiveTokens = estimateNativeCompactionTokens(
+				context.sessionManager.getBranch(),
+				keepRecentTokens,
+			);
 			const contextWindowTokens = validPositiveInteger(usage?.contextWindow)
 				? usage.contextWindow
 				: validPositiveInteger(context.model?.contextWindow)
@@ -302,7 +314,7 @@ export function createOnlineContextCompactExtension(options: OnlineContextCompac
 				economics: DEFAULT_COMPACTION_ECONOMICS,
 			});
 			const decision: CompactionDecision =
-				priced.compact && !nativeCompactionFeasible(context.sessionManager.getBranch(), keepRecentTokens)
+				priced.compact && archiveTokens === 0
 					? { ...priced, compact: false, reason: "native_not_compactable" }
 					: priced;
 			if (!decision.compact) return;

--- a/src/sol-pi/extensions/online-context-compact/index.ts
+++ b/src/sol-pi/extensions/online-context-compact/index.ts
@@ -19,6 +19,7 @@ export {
 	createOnlineContextCompactExtension,
 	DEFAULT_KEEP_RECENT_TOKENS,
 	DEFAULT_NATIVE_SUMMARY_TOKEN_ESTIMATE,
+	estimateNativeCompactionTokens,
 	POST_COMPACTION_PLAN_REMINDER,
 	type OnlineContextCompactOptions,
 	resolveKeepRecentTokens,

--- a/tests/online-context-compact.test.ts
+++ b/tests/online-context-compact.test.ts
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: MIT
  */
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { CompactOptions, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	estimateTokens,
+	type CompactOptions,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import {
 	BOUNDARY_COMPACTION_INSTRUCTIONS,
 	createOnlineContextCompactExtension,
 	DEFAULT_KEEP_RECENT_TOKENS,
+	DEFAULT_NATIVE_SUMMARY_TOKEN_ESTIMATE,
+	estimateNativeCompactionTokens,
 	POST_COMPACTION_PLAN_REMINDER,
 	registerOnlineContextCompact,
 	resolveKeepRecentTokens,
@@ -89,9 +95,105 @@ describe("Online Context Compact extension", () => {
 		expect(await pi.emitContext(messages, context)).toEqual(messages);
 	});
 
+	it("matches Pi's removable messages across initial and repeated compactions", () => {
+		const manager = new FakeSessionManager();
+		manager.appendMessage({ role: "user", content: "x".repeat(100), timestamp: Date.now() });
+		manager.appendMessage(assistant("y".repeat(100_000)));
+		const initialEntries = manager.getBranch();
+		const initialMessage = initialEntries[0];
+		if (initialMessage?.type !== "message") throw new Error("expected message entry");
+		const initialExpected = estimateTokens(initialMessage.message);
+		expect(estimateNativeCompactionTokens(initialEntries, 20_000)).toBe(initialExpected);
+		expect(initialExpected).toBeLessThan(DEFAULT_NATIVE_SUMMARY_TOKEN_ESTIMATE);
+
+		const firstKeptEntryId = manager.entries.at(-1)?.id ?? "message-2";
+		manager.entries.push({
+			type: "compaction",
+			id: "compact-1",
+			parentId: firstKeptEntryId,
+			timestamp: new Date().toISOString(),
+			summary: "s".repeat(8_000),
+			firstKeptEntryId,
+			tokensBefore: 25_025,
+		});
+		manager.leafId = "compact-1";
+		manager.appendMessage({ role: "user", content: "new work", timestamp: Date.now() });
+		manager.appendMessage(assistant("z".repeat(8_000)));
+		const repeatedEntries = manager.getBranch();
+		const previousSummary = repeatedEntries.findLast((entry) => entry.type === "compaction");
+		if (!previousSummary) throw new Error("expected compaction entry");
+		const previousSummaryMessage: AgentMessage = {
+			role: "compactionSummary",
+			summary: previousSummary.summary,
+			tokensBefore: previousSummary.tokensBefore,
+			timestamp: new Date(previousSummary.timestamp).getTime(),
+		};
+		const firstKept = repeatedEntries.find((entry) => entry.id === previousSummary.firstKeptEntryId);
+		const newUser = repeatedEntries.at(-2);
+		if (firstKept?.type !== "message" || newUser?.type !== "message") {
+			throw new Error("expected removable message entries");
+		}
+		const repeatedExpected =
+			estimateTokens(previousSummaryMessage) + estimateTokens(firstKept.message) + estimateTokens(newUser.message);
+		expect(estimateNativeCompactionTokens(repeatedEntries, 1)).toBe(repeatedExpected);
+
+		const noNewPrefix = repeatedEntries.slice(0, repeatedEntries.indexOf(previousSummary) + 2);
+		expect(estimateNativeCompactionTokens(noNewPrefix, 20_000)).toBe(0);
+	});
+
+	it("defers when Pi's cut point leaves too little history to offset the summary", async () => {
+		const manager = new FakeSessionManager();
+		manager.appendMessage({ role: "user", content: "x".repeat(100), timestamp: Date.now() });
+		manager.appendMessage(assistant("y".repeat(100_000)));
+		const pi = new FakePi(manager);
+		createOnlineContextCompactExtension({ cacheWriteReadRatio: 12.5 })(pi.asExtensionApi());
+		const abort = vi.fn();
+		const compact = vi.fn();
+		const context = fakeContext(manager, {
+			abort,
+			compact,
+			getContextUsage: () => ({ tokens: 25_025, contextWindow: 30_000, percent: 83.4 }),
+		});
+
+		await pi.emit("session_start", { type: "session_start" }, context);
+		await pi.emitContext(
+			[
+				{ role: "user", content: "x".repeat(100), timestamp: Date.now() },
+				assistant("y".repeat(100_000)),
+			],
+			context,
+		);
+		await pi.emit("before_provider_request", { type: "before_provider_request", payload: {} }, context);
+		await runPlan(pi, context, "plan-open", { steps: OPEN });
+		await runPlan(pi, context, "plan-done", { steps: DONE, progress: PROGRESS });
+		await pi.emit(
+			"turn_end",
+			{
+				type: "turn_end",
+				turnIndex: 1,
+				message: assistant("boundary"),
+				toolResults: [
+					{
+						role: "toolResult",
+						toolCallId: "plan-done",
+						toolName: "update_plan",
+						content: [{ type: "text", text: "done" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			context,
+		);
+
+		expect(abort).not.toHaveBeenCalled();
+		await pi.emit("agent_settled", { type: "agent_settled" }, context);
+		expect(compact).not.toHaveBeenCalled();
+	});
+
 	it("stops at an eligible completed-step boundary, then compacts after settlement", async () => {
 		const manager = new FakeSessionManager();
-		manager.appendMessage({ role: "user", content: `old ${"x".repeat(2_000)}`, timestamp: Date.now() });
+		manager.appendMessage({ role: "user", content: `old ${"x".repeat(8_000)}`, timestamp: Date.now() });
 		manager.appendMessage(assistant(`work ${"y".repeat(2_000)}`));
 		const pi = new FakePi(manager);
 		createOnlineContextCompactExtension({ cacheWriteReadRatio: 12.5, keepRecentTokens: 1 })(pi.asExtensionApi());
@@ -213,7 +315,7 @@ describe("Online Context Compact extension", () => {
 
 function buildSessionMessages(): AgentMessage[] {
 	return [
-		{ role: "user", content: `old ${"x".repeat(2_000)}`, timestamp: Date.now() },
+		{ role: "user", content: `old ${"x".repeat(8_000)}`, timestamp: Date.now() },
 		assistant(`work ${"y".repeat(2_000)}`),
 	];
 }


### PR DESCRIPTION
## Summary

- estimate OCC's removable history from Pi's actual `findCutPoint()` ranges
- include a replaced previous compaction summary only when there is new history to compact
- use the cut-point-aware estimate for the economic decision, debt repayment, and savings display
- add regression coverage for oversized retained messages, repeated compactions, and no-new-prefix sessions

Fixes #5.

## Why

OCC previously used `writeTokens - systemPromptTokens - keepRecentTokens`. Pi preserves whole messages at valid cut points, so a recent message larger than the retention budget can leave only a tiny removable prefix. That could make OCC report positive savings and compact even when its own 1,000-token memo estimate implied negative savings.

For the regression fixture, the old estimate was 5,025 removable tokens while Pi's cut point exposed only 25. The new estimate follows the same history and split-turn ranges Pi summarizes, so the extension defers instead of aborting the run for an uneconomic compaction.

## Validation

```text
npm run check

Test Files  17 passed (17)
Tests       136 passed (136)
```

`npm run check` also passed TypeScript validation and `npm pack --dry-run`.
