### PR TITLE
perf: reuse verified reducer receipts within a session

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,6 +33,18 @@ All persistent paths use `SessionManager.getSessionDir()` and `getSessionId()`, 
 
 The unpublished shared artifact layout is not read or migrated. Each session starts from its own `<sessionDir>/sol-pi/<sessionId>/` directory.
 
+Accepted reducer receipts are reused from a session-local, in-memory LRU cache
+of at most 64 entries. Reuse requires identical source bytes, command, error
+status, configured reducer provider/model, output limit, receipt schema, and
+reducer instructions. Every hit still verifies the source archive and validates
+the quoted evidence, then rebuilds the receipt for the current tool result.
+Hits record a `cache_hit` journal event and zero new reducer token usage; they do
+not record another provider response. Failed or rejected reductions are never
+cached. The cache adds no files and is empty after a process restart. Concurrent
+first occurrences may still make separate model calls; this cache reuses only
+completed, accepted results. Actual cost savings depend on repeated identical
+logs and the configured model's billing.
+
 ## Online Context Compact
 
 Online Context Compact uses ordinary public `context` and `before_provider_request` handlers instead of fork-only post-transform observer methods. Public handlers run in extension load order, so the SoL-Pi entrypoint registers Online Context Compact after its other context transformers. A third-party transformer loaded later is outside the context-growth observation used by its estimate.

--- a/src/sol-pi/extensions/evidence-preserving-reducer/cache.ts
+++ b/src/sol-pi/extensions/evidence-preserving-reducer/cache.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+import type { ProviderResult } from "./provider.ts";
+
+/** Only accepted receipts enter this bounded, session-local LRU cache. */
+export class ReceiptCache {
+	private readonly entries = new Map<string, ProviderResult>();
+
+	constructor(private readonly capacity = 64) {}
+
+	get(key: string): ProviderResult | undefined {
+		const value = this.entries.get(key);
+		if (!value) return undefined;
+		this.entries.delete(key);
+		this.entries.set(key, value);
+		// Reuse the evidence, not the usage charged for the original request.
+		return {
+			...value,
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+		};
+	}
+
+	set(key: string, value: ProviderResult): void {
+		this.entries.delete(key);
+		this.entries.set(key, value);
+		if (this.entries.size > this.capacity) {
+			const oldest = this.entries.keys().next().value;
+			if (oldest !== undefined) this.entries.delete(oldest);
+		}
+	}
+
+	delete(key: string): void {
+		this.entries.delete(key);
+	}
+}

--- a/src/sol-pi/extensions/evidence-preserving-reducer/index.ts
+++ b/src/sol-pi/extensions/evidence-preserving-reducer/index.ts
@@ -28,6 +28,7 @@ import type {
 import { runtimeRoot } from "../../runtime-paths.ts";
 import { formatSavingsBytes, showSolPiSavings } from "../../tui.ts";
 import { archiveBody, archiveRoot } from "./archive.ts";
+import { ReceiptCache } from "./cache.ts";
 import { reducibleToolResult } from "./candidate.ts";
 import {
 	DIAGNOSTIC_COMMAND,
@@ -41,7 +42,7 @@ import {
 } from "./config.ts";
 import { createJournal, type Journal } from "./journal.ts";
 import { callReducer, type ProviderResult } from "./provider.ts";
-import { receiptText, validateReceipt } from "./receipt.ts";
+import { receiptText, reducerInstructions, validateReceipt } from "./receipt.ts";
 
 export interface ReducedToolResult {
 	readonly content: ToolResultEvent["content"];
@@ -60,6 +61,7 @@ export async function reduceToolResult(
 	config: ReducerConfig,
 	event: ToolResultEvent,
 	context: ExtensionContext,
+	cache?: ReceiptCache,
 ): Promise<ReducedToolResult | undefined> {
 	const reducible = await reducibleToolResult(event);
 	if (!reducible || !DIAGNOSTIC_COMMAND.test(reducible.command)) return undefined;
@@ -85,9 +87,21 @@ export async function reduceToolResult(
 		sourcePath: archive.path,
 	});
 
+	const cacheKey = sha256(JSON.stringify([
+		config.storeRoot,
+		archive.hash,
+		command,
+		event.isError,
+		config.reducerProvider,
+		config.reducerModel,
+		config.maxOutputTokens,
+		REDUCER_RECEIPT_SCHEMA,
+		reducerInstructions(),
+	]));
+	const cached = cache?.get(cacheKey);
 	let provider: ProviderResult;
 	try {
-		provider = await callReducer(config, command, event.isError, archive, body, context);
+		provider = cached ?? (await callReducer(config, command, event.isError, archive, body, context));
 	} catch (error) {
 		const name = errorName(error);
 		journal("fallback", {
@@ -103,7 +117,7 @@ export async function reduceToolResult(
 		return undefined;
 	}
 
-	journal("provider_response", {
+	journal(cached ? "cache_hit" : "provider_response", {
 		toolCallId: event.toolCallId,
 		sourceSha256: archive.hash,
 		provider: provider.provider,
@@ -125,6 +139,7 @@ export async function reduceToolResult(
 
 	const checked = validateReceipt(provider.outputText, archive, body, event.isError);
 	if (!checked.ok) {
+		cache?.delete(cacheKey);
 		journal("fallback", {
 			toolCallId: event.toolCallId,
 			sourceSha256: archive.hash,
@@ -136,6 +151,7 @@ export async function reduceToolResult(
 	const receipt = receiptText(command, archive, checked.value, provider);
 	const receiptBytes = Buffer.byteLength(receipt, "utf8");
 	if (receiptBytes >= archive.bytes) {
+		cache?.delete(cacheKey);
 		journal("fallback", {
 			toolCallId: event.toolCallId,
 			sourceSha256: archive.hash,
@@ -146,6 +162,7 @@ export async function reduceToolResult(
 		});
 		return undefined;
 	}
+	if (!cached) cache?.set(cacheKey, provider);
 	journal("applied", {
 		toolCallId: event.toolCallId,
 		commandSha256: sha256(command),
@@ -155,6 +172,7 @@ export async function reduceToolResult(
 		receiptBytes,
 		evidenceCount: checked.value.evidence.length,
 		uncertain: checked.value.uncertain,
+		cacheHit: cached !== undefined,
 		usage: provider.usage,
 	});
 	showSolPiSavings(context, "Luna Delegating", formatSavingsBytes(archive.bytes - receiptBytes));
@@ -178,7 +196,7 @@ export async function reduceToolResult(
 
 export function createEvidencePreservingReducerExtension(options: EvidencePreservingReducerOptions = {}): ExtensionFactory {
 	return (pi: ExtensionAPI) => {
-		const states = new Map<string, { config: ReducerConfig; journal: Journal }>();
+		const states = new Map<string, { config: ReducerConfig; journal: Journal; cache: ReceiptCache }>();
 		pi.on("tool_result", (event, context) => {
 			let root: string;
 			try {
@@ -189,10 +207,10 @@ export function createEvidencePreservingReducerExtension(options: EvidencePreser
 			let state = states.get(root);
 			if (!state) {
 				const config = loadReducerConfig(root, options);
-				state = { config, journal: createJournal(pi, config) };
+				state = { config, journal: createJournal(pi, config), cache: new ReceiptCache() };
 				states.set(root, state);
 			}
-			return reduceToolResult(state.journal, state.config, event, context);
+			return reduceToolResult(state.journal, state.config, event, context, state.cache);
 		});
 	};
 }

--- a/tests/evidence-preserving-reducer.test.ts
+++ b/tests/evidence-preserving-reducer.test.ts
@@ -14,9 +14,12 @@ import {
 	createEvidencePreservingReducerExtension,
 	DIAGNOSTIC_COMMAND,
 	loadReducerConfig,
+	reduceToolResult,
 	REDUCER_RECEIPT_SCHEMA,
 } from "../src/sol-pi/extensions/evidence-preserving-reducer/index.ts";
 import { archiveBody } from "../src/sol-pi/extensions/evidence-preserving-reducer/archive.ts";
+import { ReceiptCache } from "../src/sol-pi/extensions/evidence-preserving-reducer/cache.ts";
+import * as receiptModule from "../src/sol-pi/extensions/evidence-preserving-reducer/receipt.ts";
 import {
 	callReducer,
 	type CompatComplete,
@@ -181,6 +184,176 @@ function load(
 }
 
 describe("evidence-preserving reducer", () => {
+	describe("verified receipt reuse", () => {
+		const signal = "ERROR test target failed";
+		const body = `${signal}\n${"diagnostic output\n".repeat(400)}`;
+		const validReceipt = (input: string): ModelReceipt => ({
+			schema: REDUCER_RECEIPT_SCHEMA,
+			source_sha256: sourceHash(input),
+			status: input.includes("is_error=true") ? "failure" : "success",
+			uncertain: false,
+			evidence: [{ kind: "failure", quote: signal }],
+		});
+
+		it("reduces three identical logs once and charges no model usage for cache hits", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			const { context, manager, pi } = load(await storeRoot(), complete);
+			// Control: the same reduction path without a cache makes three calls.
+			const config = loadReducerConfig(runtimeRoot(context));
+			for (let index = 0; index < 3; index++) {
+				await reduceToolResult(() => {}, config, bashEvent(body), context);
+			}
+			expect(complete).toHaveBeenCalledTimes(3);
+			complete.mockClear();
+			for (let index = 0; index < 3; index++) {
+				const result = await pi.emit("tool_result", bashEvent(body, { toolCallId: `call-${index}` }), context) as {
+					content: { text: string }[];
+				};
+				expect(result.content[0]?.text).toContain(`quote=${JSON.stringify(signal)}`);
+				if (index > 0) expect(result.content[0]?.text).toContain("reducer_total_tokens=0");
+			}
+			expect(complete).toHaveBeenCalledTimes(1);
+			const events = manager.customEntryData();
+			expect(events.filter((entry) => entry.kind === "provider_response")).toHaveLength(1);
+			expect(events.filter((entry) => entry.kind === "cache_hit")).toHaveLength(2);
+			const applied = events.filter((entry) => entry.kind === "applied");
+			expect(applied.map((entry) => entry.cacheHit)).toEqual([false, true, true]);
+			for (const entry of applied.slice(1)) {
+				expect(entry.usage).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 });
+			}
+		});
+
+		it("invalidates cached evidence when reducer instructions change", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			const { context, pi } = load(await storeRoot(), complete);
+			await pi.emit("tool_result", bashEvent(body), context);
+			const original = receiptModule.reducerInstructions();
+			const instructions = vi.spyOn(receiptModule, "reducerInstructions").mockReturnValue(`${original}\nUpdated rules`);
+			try {
+				await pi.emit("tool_result", bashEvent(body), context);
+				expect(complete).toHaveBeenCalledTimes(2);
+			} finally {
+				instructions.mockRestore();
+			}
+		});
+
+		it("does not cache a verified receipt that is larger than the source", async () => {
+			const lines = Array.from({ length: 12 }, (_, index) => `ERROR ${index}: ${"x".repeat(400)}`);
+			const largeBody = lines.join("\n");
+			const complete = vi.fn(modelComplete(largeBody, (input) => ({
+				...validReceipt(input), evidence: lines.map((quote) => ({ kind: "failure", quote })),
+			})));
+			const { context, manager, pi } = load(await storeRoot(), complete);
+			expect(await pi.emit("tool_result", bashEvent(largeBody), context)).toBeUndefined();
+			expect(await pi.emit("tool_result", bashEvent(largeBody), context)).toBeUndefined();
+			expect(complete).toHaveBeenCalledTimes(2);
+			expect(manager.customEntryData().filter((entry) => entry.reason === "receipt-not-smaller")).toHaveLength(2);
+		});
+
+		it.each(["body", "command", "status", "provider", "model", "output-limit"])(
+			"makes a new request when %s changes",
+			async (field) => {
+				const complete = vi.fn(modelComplete(body, validReceipt));
+				const root = await storeRoot();
+				const { context } = load(root, complete, ACTIVE_MODEL, {
+					modelRegistry: {
+						find: (provider: string, id: string) => ({ ...REDUCER_MODEL, provider, id }),
+						complete,
+					} as unknown as ExtensionContext["modelRegistry"],
+				});
+				const config = loadReducerConfig(root);
+				const cache = new ReceiptCache();
+				const changedConfig = {
+					...config,
+					...(field === "provider" ? { reducerProvider: "another-provider" } : {}),
+					...(field === "model" ? { reducerModel: "another-model" } : {}),
+					...(field === "output-limit" ? { maxOutputTokens: 1024 } : {}),
+				};
+				const changedEvent = bashEvent(field === "body" ? `${body}\nnew output` : body, {
+					...(field === "command" ? { input: { command: "pytest -x" } } : {}),
+					...(field === "status" ? { isError: false } : {}),
+				});
+				expect(await reduceToolResult(() => {}, config, bashEvent(body), context, cache)).toBeDefined();
+				expect(await reduceToolResult(() => {}, changedConfig, changedEvent, context, cache)).toBeDefined();
+				expect(complete).toHaveBeenCalledTimes(2);
+			},
+		);
+
+		it("keeps caches isolated by session and extension instance", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			const root = await storeRoot();
+			const first = load(root, complete);
+			await first.pi.emit("tool_result", bashEvent(body), first.context);
+			const otherSession = load(await storeRoot(), complete);
+			await first.pi.emit("tool_result", bashEvent(body), otherSession.context);
+			const restarted = load(root, complete);
+			await restarted.pi.emit("tool_result", bashEvent(body), restarted.context);
+			expect(complete).toHaveBeenCalledTimes(3);
+		});
+
+		it("does not cache invalid evidence and retries the next occurrence", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			complete.mockImplementationOnce(modelComplete(body, (input) => ({
+				...validReceipt(input), evidence: [{ kind: "failure", quote: "invented evidence" }],
+			})));
+			const { context, pi } = load(await storeRoot(), complete);
+			expect(await pi.emit("tool_result", bashEvent(body), context)).toBeUndefined();
+			expect(await pi.emit("tool_result", bashEvent(body), context)).toBeDefined();
+			expect(await pi.emit("tool_result", bashEvent(body), context)).toBeDefined();
+			expect(complete).toHaveBeenCalledTimes(2);
+		});
+
+		it("does not cache provider errors", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			complete.mockRejectedValueOnce(new Error("provider unavailable"));
+			const { context, pi } = load(await storeRoot(), complete);
+			expect(await pi.emit("tool_result", bashEvent(body), context)).toBeUndefined();
+			expect(await pi.emit("tool_result", bashEvent(body), context)).toBeDefined();
+			expect(complete).toHaveBeenCalledTimes(2);
+		});
+
+		it("rechecks the archive before reusing a receipt", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			const { context, manager, pi } = load(await storeRoot(), complete);
+			await pi.emit("tool_result", bashEvent(body), context);
+			const candidate = manager.customEntryData().find((entry) => entry.kind === "candidate");
+			await writeFile(String(candidate?.sourcePath), "corrupted archive");
+			await expect(pi.emit("tool_result", bashEvent(body), context)).rejects.toThrow("integrity failure");
+			expect(complete).toHaveBeenCalledTimes(1);
+		});
+
+		it("reuses evidence while preserving the current fused write result", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			const { context, pi } = load(await storeRoot(), complete);
+			await pi.emit("tool_result", fusedEvent(body, false), context);
+			const next = fusedEvent(body, false);
+			next.content[0] = { type: "text", text: "Successfully wrote another file" };
+			next.details = { patch: "new patch" };
+			const result = await pi.emit("tool_result", next, context) as {
+				content: { text: string }[]; details: Record<string, unknown>;
+			};
+			expect(result.content[0]?.text).toBe("Successfully wrote another file");
+			expect(result.content[1]?.text).toContain("reducer_total_tokens=0");
+			expect(result.details.patch).toBe("new patch");
+			expect(complete).toHaveBeenCalledTimes(1);
+		});
+
+		it("evicts the least recently used receipt at the session capacity", async () => {
+			const complete = vi.fn(modelComplete(body, validReceipt));
+			const { context, pi } = load(await storeRoot(), complete);
+			for (let index = 0; index < 64; index++) {
+				await pi.emit("tool_result", bashEvent(`${body}\n${index}`), context);
+			}
+			await pi.emit("tool_result", bashEvent(`${body}\n0`), context);
+			expect(complete).toHaveBeenCalledTimes(64);
+			await pi.emit("tool_result", bashEvent(`${body}\n64`), context);
+			await pi.emit("tool_result", bashEvent(`${body}\n0`), context);
+			expect(complete).toHaveBeenCalledTimes(65);
+			await pi.emit("tool_result", bashEvent(`${body}\n1`), context);
+			expect(complete).toHaveBeenCalledTimes(66);
+		});
+	});
+
 	it("registers without an extension-specific credential", () => {
 		const pi = new FakePi();
 		expect(() => createEvidencePreservingReducerExtension()(pi.asExtensionApi())).not.toThrow();


### PR DESCRIPTION
## Problem

Repeated build/test runs can produce byte-identical diagnostic logs. Evidence-Preserving Reducer currently reuses the archived source file but still calls the reducer model for each occurrence, adding token usage and latency without new input evidence.

## Change

Reuse completed, accepted reducer responses in a per-session, in-memory LRU cache capped at 64 entries. The key covers the source hash, command, error status, configured provider/model, output limit, receipt schema, reducer instructions, and storage root.

Cache hits still verify the source archive, revalidate every quotation, and rebuild the receipt for the current tool result (including fused write/edit output). Invalid, failed, or non-shrinking reductions are not cached. Hits record a distinct `cache_hit` journal event and zero new reducer usage, avoiding duplicate accounting of the original request.

This uses existing Pi extension APIs, adds no configuration or persistent files, and does not modify Pi core. The cache is lost on process restart. Concurrent first occurrences may still issue independent requests; only completed accepted results are reused.

## Reproducible efficiency check

The new `reduces three identical logs once and charges no model usage for cache hits` test runs the reduction path with and without the cache against a mocked provider:

| Three sequential identical logs | Reducer requests |
| --- | ---: |
| Without receipt cache | 3 |
| With receipt cache | 1 |

Both cache hits retain verified evidence and report zero additional reducer tokens. This is a deterministic call-count measurement, not a paid-model benchmark or a claim about overall agent cost. Real savings depend on repeated identical logs, eviction, and provider billing.

## Validation

- `npm ci --ignore-scripts`
- `npm run check`: TypeScript, all 17 test files / 149 tests, and package dry-run passed.
- `node scripts/check-pi-compat.mjs`: passed.
- `npx vitest run tests/all-mechanisms.test.ts`: 4/4 passed.
- `git diff --check`: passed.
- `npm audit --audit-level=high`: passed; the existing lockfile reports two moderate Vitest-related findings (GHSA-82fw-gwwq-j7x9). Dependencies were not changed.

The 15 added regression cases cover repeated output, zero usage on hits, changes to source/command/status/model/provider/output limit/instructions, session/restart isolation, failed or invalid/non-shrinking receipts, archive tampering, preservation of fused results, and LRU eviction.
