### PR TITLE
fix: align Action Fusion Unicode-space paths with Pi

### DIFF
--- a/src/sol-pi/extensions/action-fusion/file-queue.ts
+++ b/src/sol-pi/extensions/action-fusion/file-queue.ts
@@ -9,13 +9,15 @@ import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const queueTails = new Map<string, Promise<void>>();
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/gu;
 
-function stripToolPathPrefix(filePath: string): string {
-	return filePath.startsWith("@") ? filePath.slice(1) : filePath;
+function normalizeToolPath(filePath: string): string {
+	const normalized = filePath.replace(UNICODE_SPACES, " ");
+	return normalized.startsWith("@") ? normalized.slice(1) : normalized;
 }
 
 export function resolveToolPath(cwd: string, filePath: string): string {
-	const stripped = stripToolPathPrefix(filePath);
+	const stripped = normalizeToolPath(filePath);
 	// Pi accepts file URLs; the queue and hash guard must use the same target.
 	const expanded = stripped.startsWith("file://") ? fileURLToPath(stripped) : stripped;
 	if (expanded === "~") return homedir();

--- a/tests/action-fusion-paths.test.ts
+++ b/tests/action-fusion-paths.test.ts
@@ -57,6 +57,14 @@ describe("Action Fusion file URL paths", () => {
 		expect(resolveToolPath(cwd, target)).toBe(target);
 	});
 
+	it.each(["\u00A0", "\u2000", "\u200A", "\u202F", "\u205F", "\u3000"])(
+		"normalizes Unicode space %s like Pi's built-in file tools",
+		(space) => {
+			const cwd = join(tmpdir(), "action-fusion-cwd");
+			expect(resolveToolPath(cwd, `target${space}file.txt`)).toBe(join(cwd, "target file.txt"));
+		},
+	);
+
 	it.each([
 		{ name: "write", prefix: "" }, { name: "edit", prefix: "" },
 		{ name: "write", prefix: "@" }, { name: "edit", prefix: "@" },
@@ -79,6 +87,33 @@ describe("Action Fusion file URL paths", () => {
 			then_run: { command: "check target" },
 		};
 		const result = await tools.get(name)!.execute("file-url", input, undefined, undefined, context(cwd));
+		expect(commands).toEqual(["check target"]);
+		expect(result.content).toContainEqual({
+			type: "text",
+			text: expect.stringMatching(/^\[then_run:succeeded\](?:\n|$)/),
+		});
+		expect(await readFile(target, "utf8")).toBe("after\n");
+	});
+
+	it.each(["write", "edit"])("runs then_run after a real %s through a Unicode-space path", async (name) => {
+		const cwd = await createTempDir();
+		const target = join(cwd, `${name} space.txt`);
+		if (name === "edit") await writeFile(target, "before\n");
+		const commands: string[] = [];
+		const tools = loadTools({
+			bashOptions: { operations: { exec: async (command, commandCwd) => {
+				commands.push(command);
+				expect(commandCwd).toBe(cwd);
+				expect(await readFile(target, "utf8")).toBe("after\n");
+				return { exitCode: 0 };
+			} } },
+		});
+		const input = {
+			path: `${name}\u00A0space.txt`,
+			...(name === "write" ? { content: "after\n" } : { edits: [{ oldText: "before", newText: "after" }] }),
+			then_run: { command: "check target" },
+		};
+		const result = await tools.get(name)!.execute("unicode-space", input, undefined, undefined, context(cwd));
 		expect(commands).toEqual(["check target"]);
 		expect(result.content).toContainEqual({
 			type: "text",


### PR DESCRIPTION
## Summary

- normalize the same Unicode space characters as Pi's built-in file tools before Action Fusion resolves its queue/hash-guard path
- preserve the existing `@`, file URL, tilde, and relative/absolute path behavior
- add resolver coverage for Pi's Unicode-space set and end-to-end `write`/`edit` regression tests

Fixes #7.

## Why

Pi 0.84.2 normalizes Unicode spaces in `write` and `edit` paths. Action Fusion previously guarded the original, unnormalized path. For a path such as `target\u00A0file.txt`, Pi successfully modified `target file.txt`, but the guard then failed with `ENOENT` and skipped `then_run`.

The fix applies the same character replacement before Action Fusion strips `@` and handles file URLs, matching Pi's ordering for this path semantic. The change is intentionally limited to the Unicode-space mismatch reported in #7.

## Validation

```text
npm run check

Test Files  17 passed (17)
Tests       142 passed (142)
```

The focused tests exercise real Pi `write` and `edit` definitions, verify the normalized file contents, and confirm the follow-up command runs. TypeScript validation, package dry-run, and `git diff --check` also pass.
