### PR TITLE
fix: scope Observation Pack send counts to session branches

### DIFF
--- a/src/sol-pi/extensions/observation-pack/index.ts
+++ b/src/sol-pi/extensions/observation-pack/index.ts
@@ -50,7 +50,7 @@ const RECALL_LIMITS = {
 
 export function createObservationPackExtension(): ExtensionFactory {
 	return (pi: ExtensionAPI) => {
-		const sentCounts = new Map<string, number>();
+		const sentCounts = new Map<string, Map<string, Map<string, number>>>();
 		const ledgers = new Map<string, Ledger>();
 		const ledgerFor = (ctx: ExtensionContext): Ledger => {
 			const root = runtimeRoot(ctx);
@@ -61,6 +61,12 @@ export function createObservationPackExtension(): ExtensionFactory {
 			}
 			return ledger;
 		};
+
+		pi.on("session_shutdown", (_event, ctx) => {
+			const root = runtimeRoot(ctx);
+			sentCounts.delete(root);
+			ledgers.delete(root);
+		});
 
 		pi.registerTool({
 			name: "obs_recall",
@@ -137,6 +143,19 @@ export function createObservationPackExtension(): ExtensionFactory {
 		pi.on("context", async (event, ctx: ExtensionContext) => {
 			const projected = [...event.messages];
 			const root = runtimeRoot(ctx);
+			const branchIds = ["<root>", ...ctx.sessionManager.getBranch().map((entry) => entry.id)];
+			const leafId = ctx.sessionManager.getLeafId() ?? "<root>";
+			let sessionCounts = sentCounts.get(root);
+			if (!sessionCounts) {
+				sessionCounts = new Map();
+				sentCounts.set(root, sessionCounts);
+			}
+			const activeCounts = new Map<string, number>();
+			for (const id of branchIds) {
+				for (const [observationId, count] of sessionCounts.get(id) ?? []) {
+					activeCounts.set(observationId, Math.max(activeCounts.get(observationId) ?? 0, count));
+				}
+			}
 			// How many provider requests each message has already been part of,
 			// counted by the assistant messages that follow it.
 			const priorAssistantCounts = new Array<number>(event.messages.length);
@@ -157,8 +176,9 @@ export function createObservationPackExtension(): ExtensionFactory {
 					if (!observation) continue;
 					await ensureStored(observation);
 
-					const sendCountKey = `${root}\0${observation.id}`;
-					const previousSends = sentCounts.get(sendCountKey) ?? priorAssistantCounts[index] ?? 0;
+					const branchSends = activeCounts.get(observation.id) ?? 0;
+					const historySends = priorAssistantCounts[index] ?? 0;
+					const previousSends = Math.max(branchSends, historySends);
 					if (previousSends < FULL_SENDS) {
 						await ledgerFor(ctx)({
 							event: "full",
@@ -170,7 +190,13 @@ export function createObservationPackExtension(): ExtensionFactory {
 							originalTokens: observation.tokens,
 							contentHash: observation.contentHash,
 						});
-						sentCounts.set(sendCountKey, previousSends + 1);
+						const nextSends = previousSends + 1;
+						if (nextSends > historySends) {
+							const leafCounts = sessionCounts.get(leafId) ?? new Map<string, number>();
+							leafCounts.set(observation.id, nextSends);
+							sessionCounts.set(leafId, leafCounts);
+							activeCounts.set(observation.id, nextSends);
+						}
 						continue;
 					}
 
@@ -198,7 +224,13 @@ export function createObservationPackExtension(): ExtensionFactory {
 						);
 					}
 					projected[index] = { ...message, content: [{ type: "text", text: placeholder }] };
-					sentCounts.set(sendCountKey, previousSends + 1);
+					const nextSends = Math.min(FULL_SENDS + 1, previousSends + 1);
+					if (nextSends > historySends) {
+						const leafCounts = sessionCounts.get(leafId) ?? new Map<string, number>();
+						leafCounts.set(observation.id, nextSends);
+						sessionCounts.set(leafId, leafCounts);
+						activeCounts.set(observation.id, nextSends);
+					}
 				} catch (error) {
 					// Fail open: a packing failure must never cost the agent its observation.
 					const reason = error instanceof Error ? error.message : String(error);

--- a/tests/all-mechanisms.test.ts
+++ b/tests/all-mechanisms.test.ts
@@ -98,7 +98,7 @@ describe("SoL-Pi entrypoint", () => {
 
 		expect(loader).toHaveBeenCalledOnce();
 		expect(pi.registeredTools.map((tool) => tool.name)).toEqual(["obs_recall"]);
-		expect([...pi.handlers.keys()].sort()).toEqual(["context", "session_start"]);
+		expect([...pi.handlers.keys()].sort()).toEqual(["context", "session_shutdown", "session_start"]);
 	});
 
 	it("passes the configured reducer provider/model route into EPR", async () => {

--- a/tests/observation-pack.test.ts
+++ b/tests/observation-pack.test.ts
@@ -128,6 +128,63 @@ describe("observation pack", () => {
 		expect(await readFile(observationPath(sessionDir, id!), "utf8")).toBe(body);
 	});
 
+	it("keeps send counts isolated across session tree branches", async () => {
+		const sessionDir = await sessionRoot();
+		const body = `branch observation\n${repeatPastThreshold("branch bytes\n")}`;
+		const message = toolResult(body);
+		const pi = observationPackPi();
+		let branch = [{ id: "branch-a" }];
+		const manager = new FakeSessionManager([], SESSION_ID, sessionDir);
+		const context = fakeContext(manager, {
+			sessionManager: {
+				...manager,
+				getBranch: () => branch,
+				getLeafId: () => branch.at(-1)?.id ?? null,
+				getSessionDir: () => sessionDir,
+				getSessionId: () => SESSION_ID,
+			} as never,
+		});
+
+		expect(resultText((await pi.emitContext([message], context))[0]!)).toBe(body);
+		expect(resultText((await pi.emitContext([message], context))[0]!)).toBe(body);
+		expect(resultText((await pi.emitContext([message], context))[0]!)).toMatch(/^\[large tool result replaced/u);
+
+		branch = [{ id: "branch-b" }];
+		expect(resultText((await pi.emitContext([message], context))[0]!)).toBe(body);
+
+		branch = [{ id: "branch-a" }];
+		expect(resultText((await pi.emitContext([message], context))[0]!)).toMatch(/^\[large tool result replaced/u);
+	});
+
+	it("inherits send counts along the active branch but not across sessions", async () => {
+		const sessionDir = await sessionRoot();
+		const body = `branch inheritance\n${repeatPastThreshold("branch bytes\n")}`;
+		const message = toolResult(body);
+		const pi = observationPackPi();
+		let branch = [{ id: "ancestor" }];
+		const manager = new FakeSessionManager([], "session-a", sessionDir);
+		const contextA = fakeContext(manager, {
+			sessionManager: {
+				...manager,
+				getBranch: () => branch,
+				getLeafId: () => branch.at(-1)?.id ?? null,
+				getSessionDir: () => sessionDir,
+				getSessionId: () => "session-a",
+			} as never,
+		});
+
+		await pi.emitContext([message], contextA);
+		await pi.emitContext([message], contextA);
+		branch = [{ id: "ancestor" }, { id: "descendant" }];
+		expect(resultText((await pi.emitContext([message], contextA))[0]!)).toMatch(/^\[large tool result replaced/u);
+
+		const contextB = fakeContext(new FakeSessionManager([], "session-b", sessionDir));
+		expect(resultText((await pi.emitContext([message], contextB))[0]!)).toBe(body);
+		await pi.emit("session_shutdown", { type: "session_shutdown" }, contextA);
+		expect(resultText((await pi.emitContext([message], contextA))[0]!)).toBe(body);
+		expect(resultText((await pi.emitContext([message], contextB))[0]!)).toBe(body);
+	});
+
 	it("announces the first measured placeholder saving only in TUI mode", async () => {
 		vi.useFakeTimers();
 		const sessionDir = await sessionRoot();


### PR DESCRIPTION
## Summary

- scope Observation Pack's transient send counters to the session-tree leaf where a request occurs
- inherit counters only from the active branch ancestry, keeping sibling branches independent
- combine transient retry counts with assistant-history reconstruction and cap stored values after placeholder transition
- clear the current session's transient counters and ledger handle on shutdown
- add branch, ancestry, session-isolation, and shutdown regressions

Fixes #12.

## Why

The previous counter key contained only the session runtime root and observation ID. After navigating to an earlier tree point, a new sibling branch therefore inherited the abandoned branch's count and received a placeholder on its first request.

The fix attaches transient request counts to immutable session leaf IDs. A descendant inherits counts from its active ancestors, while a sibling does not see counts recorded only on the other branch. Persisted assistant history remains the baseline after restart, and in-memory state only supplements requests that have not yet produced an assistant entry.

This avoids a global reset: returning from branch B to branch A preserves A's request count instead of sending the full observation again.

## Validation

```text
npm run check

Test Files  17 passed (17)
Tests       136 passed (136)
```

Focused tests also cover sibling A→B→A navigation, ancestor-to-descendant inheritance, cross-session isolation, and session shutdown cleanup. TypeScript, package dry-run, and `git diff --check` pass.
