### PR TITLE
Add literal search for archived observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ ObservationPack and Evidence-Preserving Reducer store session-specific archives 
 
 They archive eligible source material in this directory. The archived copies remain local and are not automatically deleted when the Pi session ends.
 
+`obs_recall` pages an archive when called with `id` and `offset`. Supplying a non-empty, well-formed Unicode `query` (at most 256 UTF-8 bytes) performs a case-sensitive literal byte search instead. Search results provide byte spans, LF-based line numbers, and UTF-8-safe bounded context. Use the returned `next_offset` to continue; results are capped at 20 matches and the normal 16 KiB/400-line tool-result limit, so a capped final page can require one empty continuation to confirm `eof`. Search rescans the archive prefix to recover a line number and deliberately keeps no persistent index.
+
 Online Context Compact stores its state in Pi's session log. After a successful compaction, it starts a new turn and automatically continues the active task. Cancelling the run or exiting Pi does not trigger automatic continuation.
 
 Evidence-Preserving Reducer may send eligible diagnostic-log content to its configured reducer model using Pi-managed authentication. Review [SECURITY.md](SECURITY.md) before enabling it. Do not enable remote reduction for logs that must remain local.
@@ -138,6 +140,7 @@ npm ci --ignore-scripts
 npm run check
 npm audit --audit-level=high
 node scripts/check-pi-compat.mjs
+node --experimental-strip-types scripts/compare-observation-search.mjs --out /absolute/path/observation-search.json
 ```
 
 `npm run check` covers TypeScript, the complete test suite, and package inspection. The development dependency set is pinned to Pi 0.84.2; runtime Pi packages remain peer dependencies so Pi owns their installation and upgrades.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,8 @@ This preflight does not make every valid SoL-Pi configuration all-enabled. Witho
 - `onlineContextCompact`: registers `update_plan` and boundary-driven native compaction after the other SoL-Pi context transformers.
 - `cacheWriteReadRatio`: supplies the single economic decision ratio used by Online Context Compact.
 
+`obs_recall` accepts the original `id` and optional byte `offset` paging arguments. Its optional `query` adds case-sensitive literal UTF-8 byte search; it accepts whitespace, NUL, and multiline text, but rejects empty, malformed-Unicode, or over-256-byte queries. Search offsets are inclusive match starts, matches overlap, and returned spans use 0-based byte offsets with exclusive ends. Line numbers are LF-based and 1-based (a LF belongs to the line it ends). Each result has a UTF-8-safe bounded context and `next_offset`; continue until `eof` is true. Search returns at most 20 matches and is also constrained by the existing 16 KiB/400-line result limit. A cap can require one further empty continuation to establish EOF. To avoid a persistent line index, an arbitrary search offset rescans its prefix; this trades linear local I/O for bounded memory.
+
 ## Evidence-Preserving Reducer runtime inputs
 
 The release entry supplies the run label and session-derived storage. It uses one configurable model route:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"assets",
 		"docs/compatibility.md",
 		"docs/configuration.md",
+		"scripts/compare-observation-search.mjs",
 		"scripts/check-sol-pi-config.mjs",
 		"agents-install.md",
 		"README.md",

--- a/scripts/compare-observation-search.mjs
+++ b/scripts/compare-observation-search.mjs
@@ -1,0 +1,150 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { createObservationPackExtension } from "../src/sol-pi/extensions/observation-pack/index.ts";
+import { ensureStored, observationPath, placeholderFor } from "../src/sol-pi/extensions/observation-pack/observation.ts";
+
+const outputPath = process.argv.indexOf("--out") >= 0 ? process.argv[process.argv.indexOf("--out") + 1] : undefined;
+if (!outputPath) throw new Error("Usage: node --experimental-strip-types scripts/compare-observation-search.mjs --out /absolute/result.json");
+
+const root = await mkdtemp(join(tmpdir(), "sol-pi-search-compare-"));
+const sessionId = "comparison";
+const archiveRoot = join(root, "sol-pi", sessionId);
+const initialLines = [
+	"front needle alpha",
+	"case Needle needle",
+	"repeated needle needle needle",
+];
+const boundaryPrefix = `${initialLines.join("\n")}\nboundary `;
+const body = `${boundaryPrefix}${"x".repeat(4095 - Buffer.byteLength(boundaryPrefix))}☾needle\nmiddle ${"padding\n".repeat(900)}tail needle omega`;
+if (Buffer.byteLength(body.slice(0, body.indexOf("☾n")), "utf8") !== 4095) throw new Error("boundary fixture did not cross byte 4096");
+const contentHash = createHash("sha256").update(body).digest("hex");
+const id = `obs_${createHash("sha256").update(`compare\0compare\0${contentHash}`).digest("hex").slice(0, 24)}`;
+const observation = { id, contentHash, filePath: observationPath(archiveRoot, id), toolName: "compare", text: body, bytes: Buffer.byteLength(body), lines: body.split("\n").length, tokens: Math.ceil(body.length / 4) };
+try {
+await ensureStored(observation);
+
+const registeredTools = [];
+createObservationPackExtension()({ registerTool: (tool) => registeredTools.push(tool), on: () => undefined });
+const recall = registeredTools.find((tool) => tool.name === "obs_recall");
+if (!recall) throw new Error("obs_recall was not registered");
+const context = { signal: undefined, sessionManager: { getSessionDir: () => root, getSessionId: () => sessionId } };
+const archivePath = observationPath(archiveRoot, id);
+
+function sourceStarts(query, offset = 0) {
+	const needle = Buffer.from(query);
+	const bytes = Buffer.from(body);
+	const starts = [];
+	for (let index = bytes.indexOf(needle, offset); index >= 0; index = bytes.indexOf(needle, index + 1)) starts.push(index);
+	return starts;
+}
+
+function shellLiteral(query) {
+	for (const command of [["rg", ["-F", "-n", "-b", "-o", "--no-heading", "--", query, archivePath]], ["grep", ["-F", "-b", "-o", "--", query, archivePath]]]) {
+		const result = spawnSync(command[0], command[1], { encoding: "utf8" });
+		if (result.error?.code === "ENOENT") continue;
+		if (result.status !== 0 && result.status !== 1) throw new Error(`shell baseline failed: ${command[0]} ${result.stderr ?? ""}`);
+		const starts = (result.stdout ?? "").split("\n").flatMap((line) => {
+			const match = command[0] === "rg" ? /^\d+:(\d+):/u.exec(line) : /^(\d+):/u.exec(line);
+			return match?.[1] === undefined ? [] : [Number(match[1])];
+		});
+		const argvBytes = [command[0], ...command[1]].reduce((total, argument) => total + Buffer.byteLength(argument, "utf8"), 0) + command[1].length;
+		return { command: `${command[0]} ${command[1].slice(0, 5).join(" ")}`, status: result.status, starts, stdoutBytes: Buffer.byteLength(result.stdout ?? ""), argvBytes, argvConvention: "UTF-8 executable and argument bytes separated by one NUL byte", stderr: result.stderr || undefined };
+	}
+	return { command: "unavailable", status: null, note: "Neither rg nor grep was available; shell baseline omitted." };
+}
+
+async function page() {
+	const started = performance.now();
+	let offset = 0;
+	let calls = 0;
+	let requestBytes = 0;
+	let resultBytes = 0;
+	let recalled = "";
+	for (;;) {
+		const args = { id, offset };
+		requestBytes += Buffer.byteLength(JSON.stringify(args));
+		const result = await recall.execute("compare-page", args, undefined, undefined, context);
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+		resultBytes += Buffer.byteLength(text);
+		const first = text.indexOf("\n");
+		const second = text.indexOf("\n", first + 1);
+		recalled += text.slice(second + 1);
+		const details = result.details;
+		offset = details.nextOffset;
+		calls += 1;
+		if (details.eof) break;
+	}
+	if (recalled !== body) throw new Error("paged recall did not preserve source bytes");
+	return { calls, requestBytes, resultBytes, returnedSourceBytes: Buffer.byteLength(recalled, "utf8"), elapsedMs: performance.now() - started, sourceFidelity: true };
+}
+
+async function search(query) {
+	const toolStarted = performance.now();
+	let offset = 0;
+	let calls = 0;
+	let resultBytes = 0;
+	let requestBytes = 0;
+	let scannedBytes = 0;
+	const matches = [];
+	let eof = false;
+	while (!eof) {
+		const args = { id, query, offset };
+		requestBytes += Buffer.byteLength(JSON.stringify(args));
+		const result = await recall.execute("compare", args, undefined, undefined, context);
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+		resultBytes += Buffer.byteLength(text);
+		const details = result.details;
+		scannedBytes += details.scannedBytes ?? 0;
+		matches.push(...details.matches);
+		offset = details.nextOffset;
+		eof = details.eof;
+		calls += 1;
+		if (calls > 100) throw new Error("search did not converge");
+	}
+	const toolElapsedMs = performance.now() - toolStarted;
+	const shellStarted = performance.now();
+	const shell = shellLiteral(query);
+	return { calls, requestBytes, resultBytes, scannedBytes, toolElapsedMs, shellElapsedMs: performance.now() - shellStarted, matches, sourceStarts: sourceStarts(query), shell };
+}
+
+const started = performance.now();
+const queries = ["needle", "Needle", "☾n", "missing"];
+const searches = {};
+for (const query of queries) searches[query] = await search(query);
+const paging = await page();
+const elapsedMs = performance.now() - started;
+for (const [query, result] of Object.entries(searches)) {
+	const starts = result.matches.map((match) => match.byteOffset);
+	if (JSON.stringify(starts) !== JSON.stringify(result.sourceStarts)) throw new Error(`source mismatch for ${query}`);
+	if (result.shell.status === 0 && JSON.stringify(starts) !== JSON.stringify(result.shell.starts)) throw new Error(`shell source mismatch for ${query}`);
+	if (result.shell.status === 1 && (starts.length !== 0 || result.shell.starts.length !== 0)) throw new Error(`shell miss mismatch for ${query}`);
+	for (const match of result.matches) {
+		if (Buffer.from(body).subarray(match.contextStart, match.contextEnd).toString("utf8") !== match.context) throw new Error(`context mismatch for ${query}`);
+	}
+}
+const schema = recall.parameters;
+const baselineDescription = "Read a stored large tool result by observation id and byte offset.";
+const baselinePrompt = "Recall a paged excerpt from a previously replaced large tool result";
+const baselineSchema = { type: "object", required: ["id"], properties: { id: { type: "string", description: "Observation id from a placeholder" }, offset: { type: "integer", minimum: 0, description: "Byte offset, default 0" } } };
+const baselinePlaceholderBytes = Buffer.byteLength(placeholderFor(observation).replace("; add query for literal search; continue with next_offset", "; continue with returned next_offset"));
+const oldBytes = { schema: Buffer.byteLength(JSON.stringify(baselineSchema)), description: Buffer.byteLength(baselineDescription), promptSnippet: Buffer.byteLength(baselinePrompt), placeholder: baselinePlaceholderBytes };
+const newBytes = { schema: Buffer.byteLength(JSON.stringify(schema)), description: Buffer.byteLength(recall.description), promptSnippet: Buffer.byteLength(recall.promptSnippet), placeholder: Buffer.byteLength(placeholderFor(observation)) };
+const report = {
+	method: "real registered obs_recall against a synthetic session archive; Buffer literal scan is the source-position oracle; rg -F or grep -F is an ordinary-shell literal baseline when available",
+	limits: "No model calls. Timings are one-run descriptive wall times, not general performance evidence. Search scannedBytes is prefix plus search scan bytes and excludes context excerpt reads. The synthetic archive path is known internally; discovery is excluded. Shell argv bytes use NUL separators and are command serialization only, not Pi Bash schema or billing. Shell wall time includes process startup and file I/O; shell archive bytes scanned, Pi transport, model billing, and tokenizer counts are unavailable (null), not zero.",
+	baseline: { schema: baselineSchema, description: baselineDescription, promptSnippet: baselinePrompt, placeholderBytes: baselinePlaceholderBytes },
+	newTool: { schema, description: recall.description, promptSnippet: recall.promptSnippet, placeholderBytes: Buffer.byteLength(placeholderFor(observation)) },
+	byteTotals: { baseline: oldBytes, new: newBytes, delta: Object.fromEntries(Object.keys(oldBytes).map((key) => [key, newBytes[key] - oldBytes[key]])) },
+	bodyBytes: Buffer.byteLength(body), elapsedMs, paging, searches,
+};
+await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ outputPath, elapsedMs, queries }));
+} finally {
+	await rm(root, { recursive: true, force: true });
+}

--- a/src/sol-pi/extensions/observation-pack/index.ts
+++ b/src/sol-pi/extensions/observation-pack/index.ts
@@ -17,6 +17,7 @@
  * Storage lives under the active Pi session directory.
  */
 
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext, ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
@@ -34,6 +35,8 @@ import {
 	isPureTextResult,
 	observationPath,
 	placeholderFor,
+	SEARCH_MAX_MATCHES,
+	searchObservation,
 	type RecallChunk,
 	readRecallChunk,
 } from "./observation.ts";
@@ -47,6 +50,18 @@ const RECALL_LIMITS = {
 	maxBytes: RECALL_MAX_BYTES - RECALL_HEADER_RESERVE_BYTES,
 	maxLines: RECALL_MAX_LINES - RECALL_HEADER_LINES,
 };
+
+function isWellFormedUnicode(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+			index += 1;
+		} else if (code >= 0xdc00 && code <= 0xdfff) return false;
+	}
+	return true;
+}
 
 export function createObservationPackExtension(): ExtensionFactory {
 	return (pi: ExtensionAPI) => {
@@ -65,16 +80,71 @@ export function createObservationPackExtension(): ExtensionFactory {
 		pi.registerTool({
 			name: "obs_recall",
 			label: "Recall Observation",
-			description: "Read a stored large tool result by observation id and byte offset.",
-			promptSnippet: "Recall a paged excerpt from a previously replaced large tool result",
+			description: "Read a stored large tool result by byte offset, or search it for literal UTF-8 text.",
+			promptSnippet: "Recall pages or search a replaced large tool result with obs_recall",
 			renderShell: "self",
 			parameters: Type.Object({
 				id: Type.String({ description: "Observation id from a placeholder" }),
 				offset: Type.Optional(Type.Integer({ minimum: 0, description: "Byte offset, default 0" })),
+				query: Type.Optional(Type.String({ description: "Literal UTF-8 search text (up to 256 bytes)" })),
 			}),
-			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 				if (!isObservationId(params.id)) throw new Error(`Unknown observation id: ${params.id}`);
 				const offset = params.offset ?? 0;
+				if (!Number.isSafeInteger(offset) || offset < 0) throw new Error("Offset must be a non-negative safe integer");
+				if (params.query !== undefined) {
+					if (params.query.length === 0) throw new Error("Search query must not be empty");
+					if (!isWellFormedUnicode(params.query)) throw new Error("Search query must be well-formed Unicode");
+					const query = Buffer.from(params.query, "utf8");
+					if (query.length > 256) throw new Error("Search query exceeds 256 UTF-8 bytes");
+					const activeSignal = signal ?? ctx.signal;
+					let search;
+					try {
+						search = await searchObservation(
+							observationPath(runtimeRoot(ctx), params.id),
+							query,
+							offset,
+							RECALL_MAX_BYTES - RECALL_HEADER_RESERVE_BYTES,
+							activeSignal,
+						);
+					} catch (error) {
+						if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+							throw new Error(`Unknown observation id: ${params.id}`);
+						}
+						throw error;
+					}
+					const header = [
+						`[obs_recall search id=${params.id} offset=${offset} next_offset=${search.nextOffset} eof=${search.eof}]`,
+						`[matches=${search.matches.length}/${SEARCH_MAX_MATCHES} scanned_bytes=${search.scannedBytes}; contexts are JSON strings]`,
+					].join("\n");
+					const content = `${header}\n${search.matches.map((match) => JSON.stringify(match)).join("\n")}`;
+					if (Buffer.byteLength(content, "utf8") > RECALL_MAX_BYTES || countLines(content) > RECALL_MAX_LINES) {
+						throw new Error("Recall output exceeded its hard limit");
+					}
+					const queryHash = createHash("sha256").update(query).digest("hex");
+					await ledgerFor(ctx)({
+						event: "search",
+						id: params.id,
+						offset,
+						queryHash,
+						queryBytes: query.length,
+						matches: search.matches.length,
+						scannedBytes: search.scannedBytes,
+						nextOffset: search.nextOffset,
+						eof: search.eof,
+					});
+					return {
+						content: [{ type: "text", text: content }],
+						details: {
+							id: params.id,
+							offset,
+							matches: search.matches,
+							scannedBytes: search.scannedBytes,
+							nextOffset: search.nextOffset,
+							eof: search.eof,
+						},
+					};
+				}
 				let chunk: RecallChunk;
 				try {
 					chunk = await readRecallChunk(observationPath(runtimeRoot(ctx), params.id), offset, RECALL_LIMITS);
@@ -115,17 +185,23 @@ export function createObservationPackExtension(): ExtensionFactory {
 			},
 			renderCall(params, theme) {
 				const offset = params.offset ?? 0;
-				const base = new Text(theme.fg("dim", `Recall ${params.id} from byte ${offset}`), 0, 0);
+				const base = new Text(
+					theme.fg("dim", params.query === undefined ? `Recall ${params.id} from byte ${offset}` : `Search ${params.id} from byte ${offset}`),
+					0,
+					0,
+				);
 				return renderSolPiTool(theme, "Observation Pack", "full observation replay avoided", base);
 			},
 			renderResult(result, { isPartial }, theme) {
-				const details = result.details as { bytes?: number; lines?: number } | undefined;
+				const details = result.details as { bytes?: number; lines?: number; matches?: readonly unknown[]; scannedBytes?: number } | undefined;
 				const base = new Text(
 					theme.fg(
 						isPartial ? "warning" : "dim",
 						isPartial
 							? "Recalling the requested slice..."
-							: `Recalled ${details?.bytes ?? 0} bytes across ${details?.lines ?? 0} lines`,
+							: details?.matches
+								? `Found ${details.matches.length} matches after scanning ${details.scannedBytes ?? 0} bytes`
+								: `Recalled ${details?.bytes ?? 0} bytes across ${details?.lines ?? 0} lines`,
 					),
 					0,
 					0,

--- a/src/sol-pi/extensions/observation-pack/observation.ts
+++ b/src/sol-pi/extensions/observation-pack/observation.ts
@@ -20,6 +20,9 @@ const CHARS_PER_TOKEN = 4;
 const OBSERVATION_ID_PATTERN = /^obs_[a-f0-9]{24}$/u;
 const READ_OBJECT_FLAGS = constants.O_RDONLY | constants.O_NOFOLLOW;
 const CREATE_OBJECT_FLAGS = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW;
+export const SEARCH_MAX_MATCHES = 20;
+const SEARCH_READ_BYTES = 4096;
+const SEARCH_CONTEXT_BYTES = 256;
 
 /**
  * Receipts from the evidence-preserving reducer are already a reduction of a
@@ -187,7 +190,7 @@ export function placeholderFor(observation: Observation): string {
 		`original_bytes: ${observation.bytes}`,
 		`original_lines: ${observation.lines}`,
 		`estimated_tokens: ${observation.tokens}`,
-		`retrieve: call obs_recall with {"id":"${observation.id}","offset":0}; continue with returned next_offset`,
+		`retrieve: call obs_recall with {"id":"${observation.id}","offset":0}; add query for literal search; continue with next_offset`,
 		`[first complete lines, up to ${headBudget} bytes]`,
 		head,
 		`[middle omitted; last complete lines, up to ${tailBudget} bytes]`,
@@ -204,10 +207,158 @@ export interface RecallChunk {
 	readonly eof: boolean;
 }
 
+export interface SearchMatch {
+	readonly byteOffset: number;
+	readonly byteEnd: number;
+	readonly line: number;
+	readonly contextStart: number;
+	readonly contextEnd: number;
+	readonly context: string;
+}
+
+export interface SearchResult {
+	readonly matches: readonly SearchMatch[];
+	readonly nextOffset: number;
+	readonly eof: boolean;
+	readonly scannedBytes: number;
+}
+
 function trimUtf8End(buffer: Buffer, limit: number): number {
 	let end = limit;
 	while (end > 0 && end < buffer.length && ((buffer[end] ?? 0) & 0xc0) === 0x80) end -= 1;
 	return end;
+}
+
+function trimUtf8Start(buffer: Buffer, start: number): number {
+	let result = start;
+	while (result < buffer.length && ((buffer[result] ?? 0) & 0xc0) === 0x80) result += 1;
+	return result;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+	if (signal?.aborted) throw new Error("Observation search aborted");
+}
+
+async function readSnapshot(
+	handle: FileHandle,
+	buffer: Buffer,
+	position: number,
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	let total = 0;
+	while (total < buffer.length) {
+		throwIfAborted(signal);
+		const { bytesRead } = await handle.read(buffer, total, buffer.length - total, position + total);
+		if (bytesRead === 0) throw new Error("Stored observation shrank during search");
+		total += bytesRead;
+	}
+}
+
+async function countPrefixLines(
+	handle: FileHandle,
+	offset: number,
+	signal: AbortSignal | undefined,
+): Promise<{ lines: number; bytes: number }> {
+	let position = 0;
+	let lines = 1;
+	while (position < offset) {
+		const length = Math.min(SEARCH_READ_BYTES, offset - position);
+		const buffer = Buffer.alloc(length);
+		await readSnapshot(handle, buffer, position, signal);
+		for (const byte of buffer) if (byte === 0x0a) lines += 1;
+		position += length;
+	}
+	return { lines, bytes: position };
+}
+
+async function contextFor(
+	handle: FileHandle,
+	size: number,
+	byteOffset: number,
+	byteEnd: number,
+	signal: AbortSignal | undefined,
+): Promise<Omit<SearchMatch, "byteOffset" | "byteEnd" | "line">> {
+	const windowStart = Math.max(0, byteOffset - SEARCH_CONTEXT_BYTES);
+	const windowEnd = Math.min(size, byteEnd + SEARCH_CONTEXT_BYTES);
+	// Read enough lookahead to tell whether the fixed window ends in a UTF-8
+	// continuation byte. The returned range remains bounded by windowEnd.
+	const buffer = Buffer.alloc(Math.min(size, windowEnd + 3) - windowStart);
+	await readSnapshot(handle, buffer, windowStart, signal);
+	const start = trimUtf8Start(buffer, 0);
+	const end = trimUtf8End(buffer, windowEnd - windowStart);
+	return {
+		contextStart: windowStart + start,
+		contextEnd: windowStart + end,
+		context: buffer.subarray(start, end).toString("utf8"),
+	};
+}
+
+/**
+ * Search an archived observation as literal UTF-8 bytes. Search offsets are
+ * inclusive match starts. Line numbers require a bounded prefix rescan because
+ * archives intentionally carry no line index.
+ */
+export async function searchObservation(
+	path: string,
+	query: Buffer,
+	offset: number,
+	maxResultBytes: number,
+	signal: AbortSignal | undefined,
+): Promise<SearchResult> {
+	const handle = await open(path, READ_OBJECT_FLAGS);
+	try {
+		const fileStats = await handle.stat();
+		if (!fileStats.isFile()) throw new Error("Stored observation is not a regular file");
+		if (offset > fileStats.size) throw new Error(`Offset ${offset} exceeds observation size ${fileStats.size}`);
+		const prefix = await countPrefixLines(handle, offset, signal);
+		let position = offset;
+		let line = prefix.lines;
+		let carry = Buffer.alloc(0);
+		let scannedBytes = prefix.bytes;
+		const matches: SearchMatch[] = [];
+		while (position < fileStats.size) {
+			throwIfAborted(signal);
+			const length = Math.min(SEARCH_READ_BYTES, fileStats.size - position);
+			const chunk = Buffer.alloc(length);
+			await readSnapshot(handle, chunk, position, signal);
+			scannedBytes += length;
+			const combined = carry.length === 0 ? chunk : Buffer.concat([carry, chunk]);
+			const base = position - carry.length;
+			let combinedBaseLine = line;
+			for (const byte of carry) if (byte === 0x0a) combinedBaseLine -= 1;
+			let index = 0;
+			for (;;) {
+				throwIfAborted(signal);
+				const found = combined.indexOf(query, index);
+				if (found < 0) break;
+				const byteOffset = base + found;
+				if (byteOffset >= offset && byteOffset + query.length <= position + length) {
+					const beforeMatch = combined.subarray(0, found);
+					let matchLine = combinedBaseLine;
+					for (const byte of beforeMatch) if (byte === 0x0a) matchLine += 1;
+					const byteEnd = byteOffset + query.length;
+					const context = await contextFor(handle, fileStats.size, byteOffset, byteEnd, signal);
+					const match = { byteOffset, byteEnd, line: matchLine, ...context };
+					const serialized = Buffer.byteLength(JSON.stringify(match), "utf8") + 1;
+					const used = matches.reduce((total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1, 0);
+					if (matches.length >= SEARCH_MAX_MATCHES || used + serialized > maxResultBytes) {
+						return { matches, nextOffset: byteOffset, eof: false, scannedBytes };
+					}
+					matches.push(match);
+					if (matches.length >= SEARCH_MAX_MATCHES) {
+						return { matches, nextOffset: byteOffset + 1, eof: false, scannedBytes };
+					}
+				}
+				index = found + 1;
+			}
+			for (const byte of chunk) if (byte === 0x0a) line += 1;
+			carry = combined.subarray(Math.max(0, combined.length - (query.length - 1)));
+			position += length;
+		}
+		return { matches, nextOffset: fileStats.size, eof: true, scannedBytes };
+	} finally {
+		await handle.close();
+	}
 }
 
 export async function readRecallChunk(

--- a/tests/observation-pack.test.ts
+++ b/tests/observation-pack.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -172,6 +172,18 @@ describe("observation pack", () => {
 		expect(await readFile(join(sessionDir, "sol-pi", "session-b", "observation-pack", "objects", `${id}.txt`), "utf8")).toBe(body);
 	});
 
+	it("does not search an observation stored only in another session", async () => {
+		const sessionDir = await sessionRoot();
+		const message = toolResult(`session-only\n${repeatPastThreshold("isolated bytes\n")}`);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		const contextA = fakeContext(new FakeSessionManager([], "session-a", sessionDir));
+		const contextB = fakeContext(new FakeSessionManager([], "session-b", sessionDir));
+		await project(pi, message, sessionDir, 3);
+		await expect(pi.tool("obs_recall").execute("session-b", { id, query: "session-only" }, undefined, undefined, contextB)).rejects.toThrow("Unknown observation id");
+		await expect(pi.tool("obs_recall").execute("session-a", { id, query: "session-only" }, undefined, undefined, contextA)).resolves.toBeTruthy();
+	});
+
 	it("breaks the prefix once per observation without remutating older placeholders", async () => {
 		const sessionDir = await sessionRoot();
 		const pi = observationPackPi();
@@ -210,6 +222,8 @@ describe("observation pack", () => {
 
 		expect(recalled).toMatch(/durable observation/u);
 		expect(recalled).toMatch(/recall line/u);
+		const search = await resumed.tool("obs_recall").execute("search-after-restart", { id, query: "durable" }, undefined, undefined, fakeContext(sessionDir));
+		expect((search.details as { matches: unknown[] }).matches).toHaveLength(1);
 	});
 
 	it("fails storage closed when a same-size object holds different content", async () => {
@@ -253,9 +267,20 @@ describe("observation pack", () => {
 		await rm(path);
 		await symlink(target, path);
 
-		await expect(
-			pi.tool("obs_recall").execute("recall-1", { id, offset: 0 }, undefined, undefined, fakeContext(sessionDir)),
-		).rejects.toMatchObject({ code: "ELOOP" });
+		for (const args of [{ id, offset: 0 }, { id, query: "stored" }]) {
+			await expect(pi.tool("obs_recall").execute("recall-1", args, undefined, undefined, fakeContext(sessionDir))).rejects.toMatchObject({ code: "ELOOP" });
+		}
+	});
+
+	it("rejects a directory substituted for a searched object", async () => {
+		const sessionDir = await sessionRoot();
+		const message = toolResult(`stored\n${repeatPastThreshold("object bytes\n")}`);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		await rm(observationPath(sessionDir, id));
+		await mkdir(observationPath(sessionDir, id));
+		await expect(pi.tool("obs_recall").execute("directory", { id, query: "stored" }, undefined, undefined, fakeContext(sessionDir))).rejects.toThrow("not a regular file");
 	});
 
 	it("returns the exact original bytes across paged recall", async () => {
@@ -283,6 +308,153 @@ describe("observation pack", () => {
 
 		expect(recalled).toBe(body);
 		expect(Buffer.from(recalled, "utf8")).toEqual(Buffer.from(body, "utf8"));
+	});
+
+	it("searches archived literal bytes with exact spans, UTF-8 contexts, and overlapping matches", async () => {
+		const sessionDir = await sessionRoot();
+		const source = `start\nbanana\ncase Needle needle\nNUL:\0needle\n${"a".repeat(4094)}☾needle\n`;
+		const message = toolResult(`${source}${"padding without hits\n".repeat(700)}`);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		const recall = pi.tool("obs_recall");
+
+		const overlap = await recall.execute("search-1", { id, query: "ana" }, undefined, undefined, fakeContext(sessionDir));
+		const overlapDetails = overlap.details as { matches: Array<{ byteOffset: number; byteEnd: number; line: number; context: string }> };
+		expect(overlapDetails.matches.map((match) => match.byteOffset)).toEqual([Buffer.byteLength("start\nb", "utf8"), Buffer.byteLength("start\nban", "utf8")]);
+		expect(overlapDetails.matches.map((match) => match.byteEnd - match.byteOffset)).toEqual([3, 3]);
+		expect(overlapDetails.matches.every((match) => match.line === 2 && match.context.includes("banana"))).toBe(true);
+
+		const nul = await recall.execute("search-2", { id, query: "\0needle" }, undefined, undefined, fakeContext(sessionDir));
+		const nulText = nul.content[0]?.type === "text" ? nul.content[0].text : "";
+		expect(nulText).toContain('"context":"');
+		expect(nulText).toContain("\\u0000needle");
+		expect(Buffer.byteLength(nulText, "utf8")).toBeLessThanOrEqual(16 * 1024);
+		const utf8 = await recall.execute("search-3", { id, query: "☾n" }, undefined, undefined, fakeContext(sessionDir));
+		const utf8Details = utf8.details as { matches: Array<{ byteOffset: number; byteEnd: number; context: string }> };
+		expect(utf8Details.matches).toHaveLength(1);
+		expect(utf8Details.matches[0]?.byteOffset).toBe(Buffer.byteLength(source.slice(0, source.indexOf("☾n")), "utf8"));
+		expect(utf8Details.matches[0]?.context).toContain("☾needle");
+	});
+
+	it("trims 2, 3, and 4-byte UTF-8 characters cut by the fixed context end", async () => {
+		const sessionDir = await sessionRoot();
+		const cases = ["é", "漢", "🙂"];
+		const source = `${cases.map((character, index) => `${"x".repeat(300)}match-${index}${"a".repeat(255)}${character}tail`).join("\n")}\n${"padding\n".repeat(2_000)}`;
+		const message = toolResult(source);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		for (const [index] of cases.entries()) {
+			const result = await pi.tool("obs_recall").execute("context-boundary", { id, query: `match-${index}` }, undefined, undefined, fakeContext(sessionDir));
+			const match = (result.details as { matches: Array<{ context: string; contextStart: number; contextEnd: number }> }).matches[0];
+			expect(match).toBeTruthy();
+			const expected = Buffer.from(source).subarray(match!.contextStart, match!.contextEnd);
+			expect(Buffer.from(match!.context, "utf8")).toEqual(expected);
+			expect(match!.contextEnd - match!.contextStart).toBe(Buffer.byteLength(match!.context, "utf8"));
+			expect(match!.context).not.toContain("�");
+		}
+	});
+
+	it("continues capped searches without skipped or duplicate match starts", async () => {
+		const sessionDir = await sessionRoot();
+		const source = `${"needle|".repeat(25)}${"filler\n".repeat(2_000)}`;
+		const message = toolResult(source);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		const recall = pi.tool("obs_recall");
+		let offset = 0;
+		const starts: number[] = [];
+		for (;;) {
+			const result = await recall.execute("search-cap", { id, query: "needle", offset }, undefined, undefined, fakeContext(sessionDir));
+			const details = result.details as { matches: Array<{ byteOffset: number }>; nextOffset: number; eof: boolean };
+			starts.push(...details.matches.map((match) => match.byteOffset));
+			offset = details.nextOffset;
+			if (details.eof) break;
+		}
+		expect(starts).toEqual(Array.from({ length: 25 }, (_, index) => index * Buffer.byteLength("needle|", "utf8")));
+	});
+
+	it("stops before JSON-escaped contexts exceed the result byte limit", async () => {
+		const sessionDir = await sessionRoot();
+		const source = `${(`${"\0".repeat(256)}needle${"\0".repeat(256)}|`).repeat(20)}${"filler\n".repeat(2_000)}`;
+		const message = toolResult(source);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		const result = await pi.tool("obs_recall").execute("escaped", { id, query: "needle" }, undefined, undefined, fakeContext(sessionDir));
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+		const details = result.details as { matches: unknown[]; eof: boolean };
+		expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(16 * 1024);
+		expect(details.matches.length).toBeGreaterThan(0);
+		expect(details.matches.length).toBeLessThan(20);
+		expect(details.eof).toBe(false);
+	});
+
+	it("rejects invalid search arguments and honors an already aborted search", async () => {
+		const sessionDir = await sessionRoot();
+		const message = toolResult(`${"searchable\n".repeat(2_000)}`);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		const recall = pi.tool("obs_recall");
+		const context = fakeContext(sessionDir);
+		await expect(recall.execute("bad", { id, query: "" }, undefined, undefined, context)).rejects.toThrow("must not be empty");
+		await expect(recall.execute("bad", { id, query: String.fromCharCode(0xd800) }, undefined, undefined, context)).rejects.toThrow("well-formed");
+		await expect(recall.execute("bad", { id, query: "x".repeat(257) }, undefined, undefined, context)).rejects.toThrow("256 UTF-8");
+		await expect(recall.execute("bad", { id, query: "x", offset: Number.MAX_SAFE_INTEGER + 1 }, undefined, undefined, context)).rejects.toThrow("safe integer");
+		await expect(recall.execute("bad", { id: "obs_0123456789abcdef01234567", query: "x" }, undefined, undefined, context)).rejects.toThrow("Unknown observation id");
+		const end = Buffer.byteLength(message.content[0]?.type === "text" ? message.content[0].text : "", "utf8");
+		const miss = await recall.execute("miss", { id, query: "absent", offset: end }, undefined, undefined, context);
+		expect(miss.details).toMatchObject({ matches: [], nextOffset: end, eof: true });
+		const exact256 = await recall.execute("exact", { id, query: "é".repeat(128) }, undefined, undefined, context);
+		expect(exact256.details).toMatchObject({ matches: [], eof: true });
+		const multiline = await recall.execute("multiline", { id, query: "searchable\nsearchable" }, undefined, undefined, context);
+		expect((multiline.details as { matches: unknown[] }).matches.length).toBeGreaterThan(0);
+		const controller = new AbortController();
+		controller.abort();
+		await expect(recall.execute("abort", { id, query: "searchable" }, controller.signal, undefined, context)).rejects.toThrow("aborted");
+	});
+
+	it("accumulates short archive reads and stops when cancellation arrives during a prefix rescan", async () => {
+		const sessionDir = await sessionRoot();
+		const source = `prefix\n${"short read payload\n".repeat(2_000)}needle\n`;
+		const message = toolResult(source);
+		const id = observationId(message);
+		const pi = observationPackPi();
+		await project(pi, message, sessionDir, 3);
+		const probe = await open(observationPath(sessionDir, id), "r");
+		const prototype = Object.getPrototypeOf(probe) as { read: (...args: any[]) => Promise<{ bytesRead: number }> };
+		await probe.close();
+		const originalRead = prototype.read;
+		const readSpy = vi.spyOn(prototype, "read").mockImplementation(function (this: unknown, buffer: Buffer, bufferOffset: number, length: number, position: number) {
+			return originalRead.call(this, buffer, bufferOffset, Math.min(length, 7), position);
+		});
+		const recall = pi.tool("obs_recall");
+		const shortRead = await recall.execute("short", { id, query: "needle" }, undefined, undefined, fakeContext(sessionDir));
+		expect((shortRead.details as { matches: unknown[] }).matches).toHaveLength(1);
+
+		const controller = new AbortController();
+		let calls = 0;
+		readSpy.mockImplementation(function (this: unknown, buffer: Buffer, bufferOffset: number, length: number, position: number) {
+			calls += 1;
+			return originalRead.call(this, buffer, bufferOffset, length, position).then((result) => {
+				if (calls === 1) controller.abort();
+				return result;
+			});
+		});
+		await expect(recall.execute("during", { id, query: "needle", offset: 8_000 }, controller.signal, undefined, fakeContext(sessionDir))).rejects.toThrow("aborted");
+		const scanController = new AbortController();
+		calls = 0;
+		readSpy.mockImplementation(function (this: unknown, buffer: Buffer, bufferOffset: number, length: number, position: number) {
+			calls += 1;
+			return originalRead.call(this, buffer, bufferOffset, length, position).then((result) => {
+				if (calls === 1) scanController.abort();
+				return result;
+			});
+		});
+		await expect(recall.execute("scan", { id, query: "missing" }, scanController.signal, undefined, fakeContext(sessionDir))).rejects.toThrow("aborted");
 	});
 
 	it("fails storage closed when the observation directory is a symlink", async () => {


### PR DESCRIPTION
## Summary

- Add optional literal UTF-8 search to `obs_recall` for archived large tool results.
- Return exact byte spans, exclusive ends, LF-based line numbers, bounded UTF-8-safe source context, and continuation metadata.
- Preserve the existing paged-recall path when `query` is omitted.
- Add validation for malformed Unicode, query size, output limits, cancellation, file guards, overlaps, and continuation.
- Add a reproducible local comparison script.

## Validation

- `npm run check` — 17 test files, 142 tests, typecheck, and package dry run passed.
- `npm audit --audit-level=high` — passed at the requested severity; two pre-existing moderate Vitest advisories remain.
- `node scripts/check-pi-compat.mjs` — passed.
- `npx --no-install vitest run tests/all-mechanisms.test.ts` — 4 tests passed.
- Independent full-buffer oracle — 23 cases / 57 search calls passed.

## Real-output benchmark

Five real `rg` commands from the repository produced 30–166 KiB archived outputs. In a 50-case targeted benchmark (eight observed literals with at most 20 occurrences plus two misses per artifact):

| metric | paged recall | literal search | change |
|---|---:|---:|---:|
| tool calls | 330 | 53 | 83.94% fewer |
| returned bytes | 4,900,500 | 204,085 | 95.84% fewer |

All 50 cases were source-oracle verified, including offsets, line numbers, contexts, and continuation. A separate dense stress run is retained: queries matching nearly every line required more output than paging, which documents the feature's workload boundary.

These are retrieval measurements over real command output. They do not claim improved model-answer accuracy, provider-token usage, or billed cost. Timings are descriptive local wall times.
