### PR TITLE
fix: declare the tested minimum Pi version in peer dependencies

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # Pi Compatibility
 
-SoL-Pi is developed and tested against `@earendil-works/pi-coding-agent` 0.84.2. Its public API surface is also type-checked and exercised against Pi 0.81.1, the base used by the original Pi fork. The runtime range is deliberately expressed as a peer dependency because Pi owns installation and upgrade of its packages.
+SoL-Pi is developed and tested against `@earendil-works/pi-coding-agent` 0.84.2. Its public API surface is also type-checked and exercised against Pi 0.81.1, the base used by the original Pi fork. The runtime range is deliberately expressed as a peer dependency because Pi owns installation and upgrade of its packages; the declared floor is 0.81.1, the lowest exercised release, because earlier Pi versions predate the `@earendil-works/pi-ai/compat` export and the `agent_settled` and `sessionEntryToContextMessages` APIs SoL-Pi imports.
 
 SoL-Pi imports only public package exports:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
 				"node": ">=22.19.0"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-agent-core": "*",
-				"@earendil-works/pi-ai": "*",
-				"@earendil-works/pi-coding-agent": "*",
-				"@earendil-works/pi-tui": "*",
+				"@earendil-works/pi-agent-core": ">=0.81.1",
+				"@earendil-works/pi-ai": ">=0.81.1",
+				"@earendil-works/pi-coding-agent": ">=0.81.1",
+				"@earendil-works/pi-tui": ">=0.81.1",
 				"typebox": "*"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
 		]
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-agent-core": "*",
-		"@earendil-works/pi-ai": "*",
-		"@earendil-works/pi-coding-agent": "*",
-		"@earendil-works/pi-tui": "*",
+		"@earendil-works/pi-agent-core": ">=0.81.1",
+		"@earendil-works/pi-ai": ">=0.81.1",
+		"@earendil-works/pi-coding-agent": ">=0.81.1",
+		"@earendil-works/pi-tui": ">=0.81.1",
 		"typebox": "*"
 	},
 	"devDependencies": {

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -11,6 +11,39 @@ interface PackReport {
 	files: Array<{ path: string }>;
 }
 
+interface PackageManifest {
+	peerDependencies: Record<string, string>;
+}
+
+const piPackages = [
+	"@earendil-works/pi-agent-core",
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-coding-agent",
+	"@earendil-works/pi-tui",
+];
+
+function compareVersions(left: string, right: string): number {
+	const leftParts = left.split(".").map(Number);
+	const rightParts = right.split(".").map(Number);
+	for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index++) {
+		const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+		if (difference !== 0) return difference;
+	}
+	return 0;
+}
+
+function documentedFloor(): string {
+	const match = /the declared floor is (\d+\.\d+\.\d+)/u.exec(readFileSync("docs/compatibility.md", "utf8"));
+	if (!match?.[1]) throw new Error("docs/compatibility.md declares no peer dependency floor");
+	return match[1];
+}
+
+function declaredFloor(range: string): string {
+	const match = /\d+\.\d+\.\d+/u.exec(range);
+	if (!match) throw new Error(`Peer range declares no version floor: ${range}`);
+	return match[0];
+}
+
 function packedFiles(): string[] {
 	const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
 		cwd: process.cwd(),
@@ -44,5 +77,47 @@ describe("published package", () => {
 		expect(files).toContain("agents-install.md");
 		expect(files).not.toContain("AGENTS.md");
 		expect(files).not.toContain("CLAUDE.md");
+	});
+});
+
+describe("declared Pi compatibility", () => {
+	function manifest(): PackageManifest {
+		return JSON.parse(readFileSync("package.json", "utf8")) as PackageManifest;
+	}
+
+	function piPeerRanges(): string[] {
+		const peers = manifest().peerDependencies;
+		return piPackages.map((name) => {
+			const range = peers[name];
+			if (range === undefined) throw new Error(`Missing Pi peer dependency: ${name}`);
+			return range;
+		});
+	}
+
+	it("requires the documented Pi floor from every shared-release Pi package", () => {
+		const ranges = piPeerRanges();
+		const floor = documentedFloor();
+
+		expect(new Set(ranges).size).toBe(1);
+		for (const range of ranges) {
+			expect(range).not.toBe("*");
+			expect(declaredFloor(range), range).toBe(floor);
+		}
+	});
+
+	it("keeps the lockfile root peers in step with the manifest", () => {
+		const lockfile = JSON.parse(readFileSync("package-lock.json", "utf8")) as {
+			packages: Record<string, Partial<PackageManifest>>;
+		};
+		const locked = piPackages.map((name) => lockfile.packages[""]?.peerDependencies?.[name]);
+
+		expect(locked).toEqual(piPeerRanges());
+	});
+
+	it("excludes the Pi release that satisfies the range but cannot load SoL-Pi", () => {
+		const incompatible = "0.79.10";
+		for (const range of piPeerRanges()) {
+			expect(compareVersions(declaredFloor(range), incompatible), range).toBeGreaterThan(0);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #11.

The four Pi packages were declared as `"*"`, so npm accepted Pi 0.79.10 even though SoL-Pi cannot load against it. That release predates the `@earendil-works/pi-ai/compat` export and the `agent_settled` and `sessionEntryToContextMessages` APIs SoL-Pi imports.

The declared floor is now 0.81.1, the lowest release `docs/compatibility.md` records as exercised, and the lockfile root mirrors it. `typebox` is unchanged, and no Pi package, dependency, or runtime behavior changes.

## Regression coverage

Three assertions in `tests/package.test.ts` keep the declared contract aligned:

- every Pi peer range is identical and not `"*"`, and its floor equals the floor declared in `docs/compatibility.md`;
- the lockfile root peers match the manifest;
- the declared floor is above 0.79.10.

Each was checked against a deliberate regression. Reverting the manifest ranges to `"*"` fails all three; reverting only the lockfile entry fails the lockfile assertion, which is the drift this change also fixes.

## Validation

- Pi 0.79.10, isolated install: on the unmodified base, `node scripts/check-pi-compat.mjs` and `import('./src/sol-pi/index.ts')` both fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` for `@earendil-works/pi-ai/compat`. Pi 0.81.1 passes both. `*` accepts 0.79.10; `>=0.81.1` rejects it and still accepts 0.81.1 and 0.84.2.
- `npm run typecheck`: passed.
- `npx vitest run tests/package.test.ts -t "declared Pi compatibility"`: passed, 3 tests.
- Full suite: 132 passed, 5 failed. The same 5 fail on an unmodified base checkout — two `npm pack` cases that need a POSIX `npm` shim, two symlink cases, and one reducer case — so none are regressions. `npm run check` therefore does not complete on this Windows host; the pack cases are expected to pass in CI.
- `node scripts/check-pi-compat.mjs`: passed.
- `npm ci --ignore-scripts --dry-run`: passed.
- `npm audit --audit-level=high`: passed; the two moderate Vitest advisories are unchanged.

Tested with Node 24.14.1 and Pi 0.84.2.
