### PR TITLE
fix: report Action Fusion reachability and reducer minBytes fallbacks

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,7 +8,8 @@ SoL-Pi imports only public package exports:
 - `createWriteToolDefinition`
 - `createBashToolDefinition`
 - extension types and `ExtensionAPI.registerTool`
-- `context`, `before_provider_request`, `tool_result`, `turn_end`, `agent_settled`, and `session_before_tree` extension events
+- `ExtensionAPI.getActiveTools()` and `ExtensionAPI.getAllTools()` when present, used only for load-time reachability diagnostics
+- `context`, `before_provider_request`, `before_agent_start`, `tool_result`, `turn_end`, `agent_settled`, and `session_before_tree` extension events
 - native compaction events, `ExtensionContext.getContextUsage()`, and `ExtensionContext.compact()`
 - `ExtensionContext.model` and `ExtensionContext.modelRegistry`
 - the public session-manager methods exposed through `ExtensionContext`
@@ -21,13 +22,15 @@ Action Fusion decodes `file://` targets with Node's `fileURLToPath()` before res
 
 The queue covers only fused operations registered by this SoL-Pi instance. External processes, direct built-in-tool calls outside the replacement, and unrelated extensions are not globally locked. SoL-Pi hashes the target immediately before launching `then_run` and skips the command if it observes an intervening content change.
 
+Action Fusion's entry condition is the `then_run` parameter on the tool the model actually calls. After registration, and again on the first `before_agent_start`, SoL-Pi inspects `getActiveTools()` / `getAllTools()` when those methods exist. If no model-visible tool exposes `then_run`, it appends a `sol-pi-reachability-v1` session entry (not LLM context) and shows a TUI warning. A Pi build without those inspection APIs skips the diagnostic rather than failing to load. Code-mode and other flat-tool harnesses that already combine an edit and its follow-up command inside one model turn are outside Action Fusion's contract; the diagnostic exists so that inertness is not mistaken for a regression.
+
 ## ObservationPack
 
 ObservationPack changes only the messages projected through the public `context` event. Stored session history remains intact. Original bytes and the JSONL ledger live under the session-derived SoL-Pi directory.
 
 ## Evidence-Preserving Reducer
 
-The reducer handles public `tool_result` events and resolves the configured reducer provider/model through Pi's model registry before calling `ExtensionContext.modelRegistry.complete()` when available. For the Pi 0.81.1 fork, which exposes no registry `complete()` method, it resolves authentication for that reducer model through `getApiKeyAndHeaders()` and calls the shared `@earendil-works/pi-ai/compat` completion API. The reducer preserves the original result whenever the configured reducer model is unavailable or eligibility, model-call, schema, source-hash, exact-quote, size, or likely-secret checks fail.
+The reducer handles public `tool_result` events and resolves the configured reducer provider/model through Pi's model registry before calling `ExtensionContext.modelRegistry.complete()` when available. For the Pi 0.81.1 fork, which exposes no registry `complete()` method, it resolves authentication for that reducer model through `getApiKeyAndHeaders()` and calls the shared `@earendil-works/pi-ai/compat` completion API. The reducer preserves the original result whenever the configured reducer model is unavailable or eligibility, model-call, schema, source-hash, exact-quote, size, or likely-secret checks fail. A recovered body under `minBytes` journals `fallback` with `reason: "source-under-min-bytes"` so a quiet passing test run is distinguishable from a skipped non-candidate. The same load-time inspection used by Action Fusion warns when no configured tool is named `bash`; inner `bash` results from a flat-tool harness still count, because that tool remains in `getAllTools()` even when it is not model-visible.
 
 All persistent paths use `SessionManager.getSessionDir()` and `getSessionId()`, which are present in both the fork and Pi 0.84.2. SoL-Pi creates no configurable storage-path surface.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,9 @@ This preflight does not make every valid SoL-Pi configuration all-enabled. Witho
 
 ## Feature behavior
 
-- `actionFusion`: registers SoL-Pi replacements for Pi's `edit` and `write` tools.
+- `actionFusion`: registers SoL-Pi replacements for Pi's `edit` and `write` tools. Fusion is reachable only when a model-visible tool exposes `then_run`. A later-loaded extension that replaces that surface (for example a code-mode harness with a single `fabric_exec` tool) leaves Action Fusion registered but inert; SoL-Pi records a session diagnostic and, in TUI mode, shows a warning.
 - `observationPack`: registers `obs_recall` and a provider-context projection handler.
-- `evidencePreservingReducer`: registers a `tool_result` handler and delegates long diagnostic-log reduction to the configured reducer provider/model.
+- `evidencePreservingReducer`: registers a `tool_result` handler and delegates long diagnostic-log reduction to the configured reducer provider/model. A recovered body under 4 096 bytes is declined with a `source-under-min-bytes` journal entry rather than silently. If no configured tool reports as `bash`, SoL-Pi records the same style of load-time diagnostic used for Action Fusion.
 - `evidencePreservingReducerProvider`: provider namespace used to resolve the reducer model through Pi's model registry.
 - `evidencePreservingReducerModel`: model id used for Evidence-Preserving Reducer.
 - `onlineContextCompact`: registers `update_plan` and boundary-driven native compaction after the other SoL-Pi context transformers.

--- a/src/sol-pi/extensions/evidence-preserving-reducer/index.ts
+++ b/src/sol-pi/extensions/evidence-preserving-reducer/index.ts
@@ -64,7 +64,11 @@ export async function reduceToolResult(
 	const reducible = await reducibleToolResult(event);
 	if (!reducible || !DIAGNOSTIC_COMMAND.test(reducible.command)) return undefined;
 	const { body, command } = reducible;
-	if (Buffer.byteLength(body, "utf8") < config.minBytes) return undefined;
+	const bytes = Buffer.byteLength(body, "utf8");
+	if (bytes < config.minBytes) {
+		journal("fallback", { reason: "source-under-min-bytes", bytes, minBytes: config.minBytes });
+		return undefined;
+	}
 	if (body.length > config.maxChars) {
 		journal("fallback", { reason: "source-over-max-chars", sourceChars: body.length, maxChars: config.maxChars });
 		return undefined;

--- a/src/sol-pi/index.ts
+++ b/src/sol-pi/index.ts
@@ -9,6 +9,7 @@ import { registerActionFusion } from "./extensions/action-fusion/index.ts";
 import { registerEvidencePreservingReducer } from "./extensions/evidence-preserving-reducer/index.ts";
 import { registerObservationPack } from "./extensions/observation-pack/index.ts";
 import { registerOnlineContextCompact } from "./extensions/online-context-compact/index.ts";
+import { watchMechanismReachability } from "./reachability.ts";
 
 export function registerConfiguredFeatures(pi: ExtensionAPI, config: SolPiConfig): void {
 	if (config.actionFusion) registerActionFusion(pi);
@@ -32,7 +33,9 @@ export function createSolPiExtension(
 		pi.on("session_start", (_event, ctx) => {
 			if (initialized) return;
 			initialized = true;
-			registerConfiguredFeatures(pi, loadConfig(ctx));
+			const config = loadConfig(ctx);
+			registerConfiguredFeatures(pi, config);
+			watchMechanismReachability(pi, config, ctx);
 		});
 	};
 }

--- a/src/sol-pi/reachability.ts
+++ b/src/sol-pi/reachability.ts
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { SolPiConfig } from "./config.ts";
+
+export const REACHABILITY_EVENT_TYPE = "sol-pi-reachability-v1" as const;
+export const REACHABILITY_EVENT_SCHEMA = "sol-pi-reachability/1" as const;
+
+export interface ToolSurface {
+	readonly name: string;
+	readonly parameters?: unknown;
+}
+
+export interface ToolSurfaceSnapshot {
+	readonly active: readonly ToolSurface[];
+	readonly all: readonly ToolSurface[];
+}
+
+export interface ReachabilityFinding {
+	readonly mechanism: "actionFusion" | "evidencePreservingReducer";
+	readonly reason: "then_run-not-on-active-tools" | "bash-tool-absent";
+	readonly message: string;
+	readonly activeTools: readonly string[];
+	readonly allTools: readonly string[];
+}
+
+type ReachabilityConfig = Pick<SolPiConfig, "actionFusion" | "evidencePreservingReducer">;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function toolExposesThenRun(tool: ToolSurface): boolean {
+	if (!isRecord(tool.parameters)) return false;
+	const properties = tool.parameters.properties;
+	return isRecord(properties) && Object.hasOwn(properties, "then_run");
+}
+
+function actionFusionReachable(surface: ToolSurfaceSnapshot): boolean {
+	if (surface.active.some(toolExposesThenRun)) return true;
+	const sawSchema = surface.active.some((tool) => isRecord(tool.parameters));
+	if (sawSchema) return false;
+	return surface.active.some((tool) => tool.name === "edit" || tool.name === "write");
+}
+
+function callOrEmpty<T>(fn: (() => T) | undefined): T | undefined {
+	if (typeof fn !== "function") return undefined;
+	try {
+		return fn();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Read the tools the model can call (`getActiveTools`) and the full configured
+ * set (`getAllTools`). Missing or throwing APIs are treated as "not ready"
+ * rather than as an empty surface, so Pi 0.81.1 and test doubles without these
+ * methods do not emit false warnings.
+ */
+export function readToolSurface(pi: ExtensionAPI): ToolSurfaceSnapshot | undefined {
+	const getAllTools = callOrEmpty(pi.getAllTools?.bind(pi));
+	const getActiveTools = callOrEmpty(pi.getActiveTools?.bind(pi));
+	if (getAllTools === undefined && getActiveTools === undefined) return undefined;
+
+	const all = Array.isArray(getAllTools) ? getAllTools : [];
+	const allByName = new Map(all.map((tool) => [tool.name, tool] as const));
+	const activeNames = Array.isArray(getActiveTools) ? getActiveTools : all.map((tool) => tool.name);
+	const active = activeNames.map((name) => allByName.get(name) ?? { name });
+	if (all.length === 0 && active.length === 0) return undefined;
+	return { active, all };
+}
+
+export function reachabilityFindings(
+	config: ReachabilityConfig,
+	surface: ToolSurfaceSnapshot,
+): ReachabilityFinding[] {
+	const activeTools = surface.active.map((tool) => tool.name);
+	const allTools = surface.all.map((tool) => tool.name);
+	const findings: ReachabilityFinding[] = [];
+
+	if (config.actionFusion && !actionFusionReachable(surface)) {
+		findings.push({
+			mechanism: "actionFusion",
+			reason: "then_run-not-on-active-tools",
+			message: "Action Fusion is enabled but the tool the model calls does not expose then_run",
+			activeTools,
+			allTools,
+		});
+	}
+
+	if (config.evidencePreservingReducer && !surface.all.some((tool) => tool.name === "bash")) {
+		findings.push({
+			mechanism: "evidencePreservingReducer",
+			reason: "bash-tool-absent",
+			message: "Reducer is enabled but no tool in this session reports as bash",
+			activeTools,
+			allTools,
+		});
+	}
+
+	return findings;
+}
+
+function emitFinding(pi: ExtensionAPI, ctx: ExtensionContext, finding: ReachabilityFinding): void {
+	try {
+		pi.appendEntry(REACHABILITY_EVENT_TYPE, {
+			schema: REACHABILITY_EVENT_SCHEMA,
+			kind: "warning",
+			...finding,
+		});
+	} catch {
+		// Ephemeral sessions have nowhere to persist the diagnostic.
+	}
+	if (ctx.mode !== "tui") return;
+	try {
+		ctx.ui.notify(`⚡ SoL-Pi · ${finding.message}`, "warning");
+	} catch {
+		// Presentation is best-effort; the session entry is the durable record.
+	}
+}
+
+export function inspectMechanismReachability(
+	pi: ExtensionAPI,
+	config: ReachabilityConfig,
+	ctx: ExtensionContext,
+	warned: Set<string> = new Set(),
+): ReachabilityFinding[] {
+	if (!config.actionFusion && !config.evidencePreservingReducer) return [];
+	const surface = readToolSurface(pi);
+	if (!surface) return [];
+	const emitted: ReachabilityFinding[] = [];
+	for (const finding of reachabilityFindings(config, surface)) {
+		if (warned.has(finding.reason)) continue;
+		warned.add(finding.reason);
+		emitFinding(pi, ctx, finding);
+		emitted.push(finding);
+	}
+	return emitted;
+}
+
+/**
+ * Inspect once after SoL-Pi registers its tools, then once more on the first
+ * `before_agent_start`. The second pass catches a later-loaded extension that
+ * replaces the model-visible tool surface after `session_start`.
+ */
+export function watchMechanismReachability(
+	pi: ExtensionAPI,
+	config: ReachabilityConfig,
+	ctx: ExtensionContext,
+): void {
+	if (!config.actionFusion && !config.evidencePreservingReducer) return;
+	const warned = new Set<string>();
+	inspectMechanismReachability(pi, config, ctx, warned);
+	let probed = false;
+	pi.on("before_agent_start", (_event, agentCtx) => {
+		if (probed) return;
+		probed = true;
+		inspectMechanismReachability(pi, config, agentCtx, warned);
+	});
+}

--- a/tests/evidence-preserving-reducer.test.ts
+++ b/tests/evidence-preserving-reducer.test.ts
@@ -531,7 +531,8 @@ describe("evidence-preserving reducer", () => {
 			throw new Error("unexpected model call");
 		});
 
-		expect(await pi.emit("tool_result", bashEvent("ERROR short"), context)).toBeUndefined();
+		const shortBody = "ERROR short";
+		expect(await pi.emit("tool_result", bashEvent(shortBody), context)).toBeUndefined();
 		expect(
 			await pi.emit(
 				"tool_result",
@@ -540,5 +541,13 @@ describe("evidence-preserving reducer", () => {
 			),
 		).toBeUndefined();
 		expect(calls).toBe(0);
+		expect(manager.customEntryData()).toEqual([
+			expect.objectContaining({
+				kind: "fallback",
+				reason: "source-under-min-bytes",
+				bytes: Buffer.byteLength(shortBody, "utf8"),
+				minBytes: 4_096,
+			}),
+		]);
 	});
 });

--- a/tests/reachability.test.ts
+++ b/tests/reachability.test.ts
@@ -1,0 +1,223 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../src/sol-pi/config.ts";
+import { createSolPiExtension } from "../src/sol-pi/index.ts";
+import {
+	REACHABILITY_EVENT_SCHEMA,
+	REACHABILITY_EVENT_TYPE,
+	inspectMechanismReachability,
+	reachabilityFindings,
+	readToolSurface,
+	toolExposesThenRun,
+	watchMechanismReachability,
+	type ToolSurface,
+} from "../src/sol-pi/reachability.ts";
+import { FakePi, fakeContext } from "./helpers.ts";
+
+const thenRunParameters = Type.Object({
+	path: Type.String(),
+	then_run: Type.Optional(Type.Object({ command: Type.String() })),
+});
+
+const plainParameters = Type.Object({
+	code: Type.String(),
+});
+
+function surface(active: ToolSurface[], all: ToolSurface[] = active) {
+	return { active, all };
+}
+
+function config(overrides: Partial<typeof DEFAULT_CONFIG> = {}) {
+	return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+function installToolSurface(
+	pi: FakePi,
+	all: ToolSurface[],
+	active: string[] = all.map((tool) => tool.name),
+): void {
+	(pi as FakePi & { getAllTools: () => ToolSurface[]; getActiveTools: () => string[] }).getAllTools = () => all;
+	(pi as FakePi & { getActiveTools: () => string[] }).getActiveTools = () => active;
+}
+
+describe("mechanism reachability", () => {
+	it("detects then_run on a TypeBox tool schema", () => {
+		expect(toolExposesThenRun({ name: "edit", parameters: thenRunParameters })).toBe(true);
+		expect(toolExposesThenRun({ name: "fabric_exec", parameters: plainParameters })).toBe(false);
+		expect(toolExposesThenRun({ name: "edit" })).toBe(false);
+	});
+
+	it("keeps Action Fusion reachable when an active tool exposes then_run", () => {
+		expect(
+			reachabilityFindings(
+				config({ actionFusion: true }),
+				surface(
+					[{ name: "edit", parameters: thenRunParameters }],
+					[
+						{ name: "edit", parameters: thenRunParameters },
+						{ name: "bash", parameters: Type.Object({ command: Type.String() }) },
+					],
+				),
+			),
+		).toEqual([]);
+	});
+
+	it("reports Action Fusion inert when the model-visible tools omit then_run", () => {
+		expect(
+			reachabilityFindings(
+				config({ actionFusion: true }),
+				surface(
+					[{ name: "fabric_exec", parameters: plainParameters }],
+					[
+						{ name: "fabric_exec", parameters: plainParameters },
+						{ name: "edit", parameters: thenRunParameters },
+						{ name: "write", parameters: thenRunParameters },
+						{ name: "bash" },
+					],
+				),
+			),
+		).toEqual([
+			expect.objectContaining({
+				mechanism: "actionFusion",
+				reason: "then_run-not-on-active-tools",
+				message: "Action Fusion is enabled but the tool the model calls does not expose then_run",
+				activeTools: ["fabric_exec"],
+			}),
+		]);
+	});
+
+	it("treats inactive bash as enough for the reducer", () => {
+		expect(
+			reachabilityFindings(
+				config({ evidencePreservingReducer: true }),
+				surface([{ name: "fabric_exec", parameters: plainParameters }], [
+					{ name: "fabric_exec", parameters: plainParameters },
+					{ name: "bash" },
+				]),
+			),
+		).toEqual([]);
+	});
+
+	it("reports the reducer inert when no tool is named bash", () => {
+		expect(
+			reachabilityFindings(
+				config({ evidencePreservingReducer: true }),
+				surface([{ name: "edit", parameters: thenRunParameters }]),
+			),
+		).toEqual([
+			expect.objectContaining({
+				mechanism: "evidencePreservingReducer",
+				reason: "bash-tool-absent",
+				message: "Reducer is enabled but no tool in this session reports as bash",
+			}),
+		]);
+	});
+
+	it("skips inspection when the tool-surface APIs are missing", () => {
+		const pi = new FakePi();
+		const ctx = fakeContext(pi.sessionManager);
+		expect(readToolSurface(pi.asExtensionApi())).toBeUndefined();
+		expect(inspectMechanismReachability(pi.asExtensionApi(), config({ actionFusion: true }), ctx)).toEqual([]);
+		expect(pi.sessionManager.customEntryData()).toEqual([]);
+	});
+
+	it("writes one session entry and a TUI warning when Action Fusion is unreachable", () => {
+		const pi = new FakePi();
+		installToolSurface(
+			pi,
+			[
+				{ name: "fabric_exec", parameters: plainParameters },
+				{ name: "edit", parameters: thenRunParameters },
+				{ name: "bash" },
+			],
+			["fabric_exec"],
+		);
+		const notify = vi.fn();
+		const ctx = fakeContext(pi.sessionManager, {
+			mode: "tui",
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		});
+
+		const findings = inspectMechanismReachability(
+			pi.asExtensionApi(),
+			config({ actionFusion: true }),
+			ctx,
+		);
+
+		expect(findings).toHaveLength(1);
+		expect(pi.sessionManager.customEntryData()).toEqual([
+			expect.objectContaining({
+				schema: REACHABILITY_EVENT_SCHEMA,
+				kind: "warning",
+				reason: "then_run-not-on-active-tools",
+			}),
+		]);
+		expect(pi.sessionManager.entries[0]).toMatchObject({ customType: REACHABILITY_EVENT_TYPE });
+		expect(notify).toHaveBeenCalledWith(
+			"⚡ SoL-Pi · Action Fusion is enabled but the tool the model calls does not expose then_run",
+			"warning",
+		);
+	});
+
+	it("does not notify outside TUI mode", () => {
+		const pi = new FakePi();
+		installToolSurface(pi, [{ name: "edit" }], ["edit"]);
+		const notify = vi.fn();
+		const ctx = fakeContext(pi.sessionManager, {
+			mode: "json",
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		});
+
+		inspectMechanismReachability(pi.asExtensionApi(), config({ evidencePreservingReducer: true }), ctx);
+
+		expect(notify).not.toHaveBeenCalled();
+		expect(pi.sessionManager.customEntryData()).toContainEqual(
+			expect.objectContaining({ reason: "bash-tool-absent" }),
+		);
+	});
+
+	it("rechecks on the first before_agent_start after another extension replaces the surface", async () => {
+		const pi = new FakePi();
+		installToolSurface(pi, [{ name: "edit", parameters: thenRunParameters }], ["edit"]);
+		const ctx = fakeContext(pi.sessionManager);
+
+		watchMechanismReachability(pi.asExtensionApi(), config({ actionFusion: true }), ctx);
+		expect(pi.sessionManager.customEntryData()).toEqual([]);
+		expect([...pi.handlers.keys()]).toContain("before_agent_start");
+
+		installToolSurface(
+			pi,
+			[
+				{ name: "fabric_exec", parameters: plainParameters },
+				{ name: "edit", parameters: thenRunParameters },
+			],
+			["fabric_exec"],
+		);
+		await pi.emit("before_agent_start", { type: "before_agent_start" }, ctx);
+		await pi.emit("before_agent_start", { type: "before_agent_start" }, ctx);
+
+		expect(pi.sessionManager.customEntryData()).toEqual([
+			expect.objectContaining({ reason: "then_run-not-on-active-tools" }),
+		]);
+	});
+
+	it("wires the probe from session_start when Action Fusion is enabled", async () => {
+		const pi = new FakePi();
+		installToolSurface(pi, [{ name: "fabric_exec", parameters: plainParameters }], ["fabric_exec"]);
+		createSolPiExtension(() => config({ actionFusion: true }))(pi.asExtensionApi());
+
+		await pi.emit("session_start", { type: "session_start" }, fakeContext(pi.sessionManager));
+
+		expect(pi.registeredTools.map((tool) => tool.name)).toEqual(["edit", "write"]);
+		expect(pi.sessionManager.customEntryData()).toContainEqual(
+			expect.objectContaining({ reason: "then_run-not-on-active-tools" }),
+		);
+		expect([...pi.handlers.keys()]).toContain("before_agent_start");
+	});
+});


### PR DESCRIPTION
Fixes #22's diagnostic/observability gaps; does not make Action Fusion execute through `fabric_exec`.

## Changes

- Journal short diagnostic-body declines as `fallback` / `source-under-min-bytes`, with byte count and threshold.
- At each `before_provider_request`, check the active/configured tool surface and persist branch-deduplicated `sol-pi-reachability-v1` diagnostics (not LLM context), plus TUI warnings.
- Action Fusion requires an active SoL-Pi fused edit/write registration, identified by its registered parameter object and name—not an arbitrary tool's `then_run` field.
- Reducer accepts configured bash or an active SoL-Pi fused edit/write path, matching its candidate contract.
- No provisional session-start warning. After tree navigation, the next request re-appends a warning if absent from that branch. Missing inspection APIs skip diagnostics.

Review follow-up: `bdcd78de64197e2b681f26383f5426948ad1578f`. See the review-response comment for per-item details and evidence.

## Local verification

Pinned Pi 0.84.2:
- `npx vitest run tests/reachability.test.ts tests/action-fusion.test.ts tests/evidence-preserving-reducer.test.ts`: PASS, 49 tests.
- `npm run check`: PASS, typecheck + 157 tests / 19 files + pack dry-run.
- `node scripts/check-pi-compat.mjs`: PASS (API smoke check).
- `git diff --check` / `git diff --cached --check`: PASS. No separate formatter/linter command is configured.

Additional isolated Pi 0.81.1 run:
- Same targeted tests: PASS, 49 tests.
- `npm run check`: **FAIL**, typecheck passes, 155 tests pass, 2 existing automatic-compaction AgentSession tests fail at line 157 (call counts 4/3 and 6/5).
- Those exact failures also reproduce on previous PR head `17df74c` and upstream base `d7ecfc0` with the same dependencies. They remain unresolved, not dismissed as flaky.
- Separate `node scripts/check-pi-compat.mjs` and `npm pack --dry-run`: PASS.

GitHub CI: no PR checks reported and no PR test workflow configured; these are local results only.
