### PR TITLE
fix(observation-pack): add best-effort Windows symlink fallback without O_NOFOLLOW (#16)

### DIFF
--- a/src/sol-pi/extensions/observation-pack/observation.ts
+++ b/src/sol-pi/extensions/observation-pack/observation.ts
@@ -20,6 +20,33 @@ const CHARS_PER_TOKEN = 4;
 const OBSERVATION_ID_PATTERN = /^obs_[a-f0-9]{24}$/u;
 const READ_OBJECT_FLAGS = constants.O_RDONLY | constants.O_NOFOLLOW;
 const CREATE_OBJECT_FLAGS = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW;
+const O_NOFOLLOW_SUPPORTED = typeof constants.O_NOFOLLOW === "number";
+
+/**
+ * Best-available symlink pre-check for platforms without O_NOFOLLOW.
+ * Node leaves O_NOFOLLOW `undefined` on Windows, and `undefined`
+ * contributes 0 to the flag words above — so without this the symlink
+ * refusal would silently vanish there (#16). Gives the ELOOP the open
+ * itself would have raised. This is a pre-open lstat, not the atomic
+ * guarantee O_NOFOLLOW provides on POSIX (no pure-Node primitive on
+ * Windows preserves it); on platforms with O_NOFOLLOW the open keeps
+ * refusing atomically and this is never consulted.
+ */
+export async function assertNotSymlink(path: string): Promise<void> {
+	let stats;
+	try {
+		stats = await lstat(path);
+	} catch (error) {
+		// Absent: let open() report ENOENT itself. Anything else (EACCES,
+		// for example) is real and must surface, not vanish.
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+		throw error;
+	}
+	if (!stats.isSymbolicLink()) return;
+	throw Object.assign(new Error(`Stored observation is not a regular file: ${path}`), {
+		code: "ELOOP",
+	});
+}
 
 /**
  * Receipts from the evidence-preserving reducer are already a reduction of a
@@ -130,10 +157,12 @@ export async function ensureStored(observation: Observation): Promise<void> {
 
 	let handle: FileHandle | undefined;
 	try {
+		if (!O_NOFOLLOW_SUPPORTED) await assertNotSymlink(observation.filePath);
 		handle = await open(observation.filePath, CREATE_OBJECT_FLAGS, 0o600);
 		await handle.writeFile(observation.text, { encoding: "utf8" });
 	} catch (error) {
 		if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+		if (!O_NOFOLLOW_SUPPORTED) await assertNotSymlink(observation.filePath);
 		const existingHandle = await open(observation.filePath, READ_OBJECT_FLAGS);
 		try {
 			const existing = await existingHandle.stat();
@@ -215,6 +244,7 @@ export async function readRecallChunk(
 	offset: number,
 	limits: { readonly maxBytes: number; readonly maxLines: number },
 ): Promise<RecallChunk> {
+	if (!O_NOFOLLOW_SUPPORTED) await assertNotSymlink(path);
 	const handle = await open(path, READ_OBJECT_FLAGS);
 	try {
 		const fileStats = await handle.stat();

--- a/tests/evidence-preserving-reducer.test.ts
+++ b/tests/evidence-preserving-reducer.test.ts
@@ -293,7 +293,11 @@ describe("evidence-preserving reducer", () => {
 		const localSourcePath = relative(join(runtimeRoot(context), "evidence-preserving-reducer"), sourcePath);
 		expect(localSourcePath.length > 0 && !localSourcePath.startsWith("..") && !isAbsolute(localSourcePath)).toBe(true);
 		expect(await readFile(sourcePath, "utf8")).toBe(body);
-		expect((await stat(sourcePath)).mode & 0o777).toBe(0o600);
+		// NTFS does not surface POSIX permission bits, so the 0o600 mode has
+		// no effect there (#16). Every other assertion in this test still runs.
+		if (process.platform !== "win32") {
+			expect((await stat(sourcePath)).mode & 0o777).toBe(0o600);
+		}
 		expect(events.filter((entry) => entry.kind === "applied")).toHaveLength(1);
 		expect(notify).toHaveBeenCalledTimes(1);
 		expect(notify.mock.calls[0]?.[0]).toMatch(

--- a/tests/observation-symlink-guard.test.ts
+++ b/tests/observation-symlink-guard.test.ts
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+import { constants } from "node:fs";
+import { mkdtemp, open, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertNotSymlink } from "../src/sol-pi/extensions/observation-pack/observation.ts";
+
+// Stub only lstat; every other fs/promises export passes through untouched.
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...actual, lstat: vi.fn(actual.lstat) };
+});
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function scratchRoot(): Promise<string> {
+	const value = await mkdtemp(join(tmpdir(), "observation-symlink-guard-test-"));
+	roots.push(value);
+	return value;
+}
+
+describe("assertNotSymlink (Windows O_NOFOLLOW fallback, #16)", () => {
+	it("rejects a symlink with ELOOP", async () => {
+		const root = await scratchRoot();
+		const target = join(root, "target.txt");
+		const link = join(root, "link.txt");
+		await writeFile(target, "target bytes must not be recalled");
+		await symlink(target, link);
+
+		await expect(assertNotSymlink(link)).rejects.toMatchObject({ code: "ELOOP" });
+	});
+
+	it("resolves for a regular file", async () => {
+		const root = await scratchRoot();
+		const path = join(root, "regular.txt");
+		await writeFile(path, "ordinary bytes");
+
+		await expect(assertNotSymlink(path)).resolves.toBeUndefined();
+	});
+
+	it("resolves for an absent path so open() still reports ENOENT itself", async () => {
+		const root = await scratchRoot();
+
+		await expect(assertNotSymlink(join(root, "absent.txt"))).resolves.toBeUndefined();
+	});
+
+	it("rethrows non-ENOENT lstat failures instead of swallowing them", async () => {
+		const { lstat } = await import("node:fs/promises");
+		vi.mocked(lstat).mockRejectedValueOnce(
+			Object.assign(new Error("permission denied"), { code: "EACCES" }),
+		);
+
+		await expect(assertNotSymlink(join("anywhere", "file.txt"))).rejects.toMatchObject({
+			code: "EACCES",
+		});
+	});
+
+	// A directory at an observation path keeps failing through the callers'
+	// existing error paths (EISDIR from open, or the fstat isFile checks) —
+	// the fallback is symlink-specific, not a regular-file validator (#16).
+	it.runIf(constants.O_NOFOLLOW !== undefined)(
+		"POSIX open() refuses symlinks atomically without the fallback",
+		async () => {
+			const root = await scratchRoot();
+			const target = join(root, "target.txt");
+			const link = join(root, "link.txt");
+			await writeFile(target, "bytes");
+			await symlink(target, link);
+
+			await expect(
+				open(link, constants.O_RDONLY | (constants.O_NOFOLLOW as number)),
+			).rejects.toMatchObject({ code: "ELOOP" });
+		},
+	);
+});

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -12,7 +12,15 @@ interface PackReport {
 }
 
 function packedFiles(): string[] {
-	const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+	// child_process.spawnSync applies no PATHEXT resolution, and current
+	// Node hardening can reject a direct `.cmd` spawn with EINVAL — so on
+	// Windows run the static command line through cmd.exe instead (#16).
+	// All arguments are literals; nothing here interpolates untrusted input.
+	const command =
+		process.platform === "win32"
+			? { file: "cmd.exe", args: ["/d", "/s", "/c", "npm pack --dry-run --json"] }
+			: { file: "npm", args: ["pack", "--dry-run", "--json"] };
+	const result = spawnSync(command.file, command.args, {
 		cwd: process.cwd(),
 		encoding: "utf8",
 	});


### PR DESCRIPTION
Fixes #16.

## What was broken

`constants.O_NOFOLLOW` is `undefined` on Windows, and `undefined`
contributes `0` to a bitwise OR — so the ObservationPack symlink refusal
silently never took effect there (recall succeeded on symlinked objects
instead of ELOOP). Two POSIX-only test assumptions (`spawnSync("npm")`,
a `0o600` mode assertion) failed 3 more tests on Windows.

## What changed

- New exported `assertNotSymlink()`: `lstat` pre-check giving the ELOOP
  the open itself would have raised. Consulted before all three guarded
  opens only where `O_NOFOLLOW` is unavailable; POSIX keeps the atomic
  kernel path untouched. Missing paths fall through so `open()` still
  reports ENOENT; other `lstat` errors rethrow.
- `package.test.ts`: Windows runs the static command line through
  `cmd.exe /d /s /c` (direct `.cmd` spawn can EINVAL under current Node
  hardening; all arguments are literals).
- `evidence-preserving-reducer.test.ts`: the `0o600` assertion is skipped
  on win32 only (NTFS has no POSIX bits); every other assertion still runs.
- New `observation-symlink-guard.test.ts`: symlink→ELOOP, regular→ok,
  absent→ok, EACCES rethrown, plus a POSIX-only pin that the kernel path
  refuses atomically without the fallback. The existing ELOOP recall test
  is unchanged.

## Validation

- New suite 5/5; related suites green; existing ELOOP recall test untouched.
- `npm run check` green (typecheck + 19 files / 144 tests + pack).
- `npm audit --audit-level=high`: exit 0. `check-pi-compat.mjs`: exit 0.
- Windows execution still needs confirmation (no Windows CI here): the
  fallback helper is fully covered and POSIX is byte-identical, but the
  three gated call sites want a Windows run — the existing ELOOP recall
  test is the one to watch.\n\n## Scope note (best-effort, not atomic)\n\nOn Windows this is a best-effort pre-check, not the atomic guarantee POSIX `O_NOFOLLOW` provides: `lstat` followed by `open` leaves a TOCTOU window (a final component can be swapped before open; a checked directory can become a junction before create). It rejects an already-present stable symlink, consistent with SECURITY.md (SoL-Pi is not a sandbox or permission boundary). POSIX path unchanged and atomic.